### PR TITLE
PYG-36 PYG-50: implementando bloqueio de cadastro duplicado de portais

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/PortalController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/PortalController.java
@@ -57,8 +57,43 @@ public class PortalController {
         return "portal";
     }
 
+    @GetMapping("/verificarNome")
+    @ResponseBody
+    public Map<String, Boolean> verificarNome(@RequestParam String nome) {
+        boolean existe = portalRepository.existsByNome(nome);
+        return Map.of("existe", existe);
+    }
+
     @PostMapping("/salvar")
-    public String salvarOuAtualizarPortal(@ModelAttribute Portal portal, @RequestParam("isEdit") boolean isEdit) {
+    public String salvarOuAtualizarPortal(@ModelAttribute Portal portal, @RequestParam("isEdit") boolean isEdit, Model model) {
+        String errorMessage = null;
+
+        if (isEdit) {
+            Portal portalExistente = portalRepository.findById(portal.getId())
+                    .orElseThrow(() -> new IllegalArgumentException("ID inválido: " + portal.getId()));
+
+            if (!portal.getNome().equals(portalExistente.getNome()) && portalRepository.existsByNome(portal.getNome())) {
+                errorMessage = "Já existe um portal com esse nome.";
+            } else if (!portal.getUrl().equals(portalExistente.getUrl()) && portalRepository.existsByUrl(portal.getUrl())) {
+                errorMessage = "Já existe um portal com essa URL.";
+            }
+        } else {
+            if (portalRepository.existsByNome(portal.getNome())) {
+                errorMessage = "Já existe um portal com este nome.";
+            } else if (portalRepository.existsByUrl(portal.getUrl())) {
+                errorMessage = "Já existe um portal com esta URL.";
+            }
+        }
+
+        if (errorMessage != null) {
+            model.addAttribute("errorMessage", errorMessage);
+            model.addAttribute("portal", portal); 
+            model.addAttribute("portais", portalRepository.findAll());
+            model.addAttribute("agendadores", agendadorRepository.findAll());
+            model.addAttribute("tags", tagRepository.findAll());
+            return "portal";
+        }
+
         if (portal.getId() == null) {
             portal.setDataCriacao(LocalDate.now());
         } else {

--- a/src/main/java/edu/fatec/Porygon/repository/PortalRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/PortalRepository.java
@@ -6,4 +6,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PortalRepository extends JpaRepository<Portal, Integer> {
+
+    boolean existsByUrl(String url);
+
+    boolean existsByNome(String nome);
 }

--- a/src/main/resources/templates/portal.html
+++ b/src/main/resources/templates/portal.html
@@ -26,6 +26,9 @@
 </nav>
 
 <div class="container mt-5">
+    <div th:if="${errorMessage}" class="alert alert-danger" role="alert">
+        <span th:text="${errorMessage}"></span>
+    </div>
     <h4 class="mb-4 text-center" th:text="${portal.id} != null ? 'Editar Portal' : 'Cadastro de Portal'"></h4>
     <form th:action="@{/portais/salvar}" th:object="${portal}" method="post">
         <input type="hidden" th:field="*{id}">


### PR DESCRIPTION
Testei as implementações/mudanças, resumindo, agora os portais possuem identificadores individuais para nome e url p não existir problema se o usuário for modificar apenas 1 dos dois.
Se possuir mais de um portal registrado e o usuário for tentar modificar os dados de um dos dois, a verificação de duplicidade também será feita nesse caso, avisando se tentar inserir o nome de um portal cadastrado na edição de outro.