### PR TITLE
PYG-3-PYG-54 refactor: criar a caixa de selecao dos tipos de arquivo da api xml csv ou json da API (XML, CSV OU JSON)

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/ApiController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/ApiController.java
@@ -2,6 +2,7 @@ package edu.fatec.Porygon.controller;
 
 import edu.fatec.Porygon.model.Api;
 import edu.fatec.Porygon.repository.AgendadorRepository;
+import edu.fatec.Porygon.repository.FormatoRepository;
 import edu.fatec.Porygon.repository.TagRepository;
 import edu.fatec.Porygon.service.ApiService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +26,9 @@ public class ApiController {
     @Autowired
     private ApiService apiService;
 
+    @Autowired
+    private FormatoRepository formatoRepository;
+
     @GetMapping()
     public String mostrarFormularioCadastro(Model model) {
         Api novaApi = new Api();
@@ -32,6 +36,7 @@ public class ApiController {
         model.addAttribute("api", novaApi);
         model.addAttribute("apis", apiService.listarTodas());
         model.addAttribute("agendadores", agendadorRepository.findAll());
+        model.addAttribute("formatos", formatoRepository.findAll());
         model.addAttribute("tags", tagRepository.findAll());
         return "api";
     }
@@ -46,6 +51,7 @@ public class ApiController {
             model.addAttribute("api", api);
             model.addAttribute("apis", apiService.listarTodas());
             model.addAttribute("agendadores", agendadorRepository.findAll());
+            model.addAttribute("formatos", formatoRepository.findAll());
             model.addAttribute("tags", tagRepository.findAll());
             return "api";
         }

--- a/src/main/java/edu/fatec/Porygon/model/Api.java
+++ b/src/main/java/edu/fatec/Porygon/model/Api.java
@@ -14,7 +14,6 @@ public class Api {
     @Column(length = 1000)
     private String descricao;
     private String url;
-    private String formato;
     private LocalDate dataCriacao;
     private LocalDate ultimaAtualizacao;
 
@@ -24,11 +23,15 @@ public class Api {
 
     private boolean ativo;
 
+    @ManyToOne
+    @JoinColumn(name = "formato_id")
+    private Formato formato;
+
     @ManyToMany
     @JoinTable(
-        name = "api_tag", 
-        joinColumns = @JoinColumn(name = "api_id"), 
-        inverseJoinColumns = @JoinColumn(name = "tag_id") 
+        name = "api_tag",
+        joinColumns = @JoinColumn(name = "api_id"),
+        inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
     private List<Tag> tags;
 
@@ -64,11 +67,11 @@ public class Api {
         this.url = url;
     }
 
-    public String getFormato() {
+    public Formato getFormato() {
         return formato;
     }
 
-    public void setFormato(String formato) {
+    public void setFormato(Formato formato) {
         this.formato = formato;
     }
 
@@ -111,8 +114,4 @@ public class Api {
     public void setDataCriacao(LocalDate dataCriacao) {
         this.dataCriacao = dataCriacao;
     }
-
 }
-
-
-

--- a/src/main/java/edu/fatec/Porygon/model/Formato.java
+++ b/src/main/java/edu/fatec/Porygon/model/Formato.java
@@ -1,0 +1,40 @@
+package edu.fatec.Porygon.model;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+public class Formato {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    private String nome; 
+
+    @OneToMany(mappedBy = "formato")
+    private List<Api> apis; 
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public List<Api> getApis() {
+        return apis;
+    }
+
+    public void setApis(List<Api> apis) {
+        this.apis = apis;
+    }
+}

--- a/src/main/java/edu/fatec/Porygon/model/FormatoDataLoader.java
+++ b/src/main/java/edu/fatec/Porygon/model/FormatoDataLoader.java
@@ -1,0 +1,33 @@
+package edu.fatec.Porygon.model;
+
+import edu.fatec.Porygon.repository.FormatoRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FormatoDataLoader implements CommandLineRunner {
+
+    @Autowired
+    private FormatoRepository formatoRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (formatoRepository.count() == 0) {
+            Formato json = new Formato();
+            json.setNome("JSON");
+
+            Formato csv = new Formato();
+            csv.setNome("CSV");
+
+            Formato xml = new Formato();
+            xml.setNome("XML");
+
+            formatoRepository.save(json);
+            formatoRepository.save(csv);
+            formatoRepository.save(xml);
+
+            System.out.println("Formatos padrão inseridos no banco de dados.");
+        }
+    }
+}

--- a/src/main/java/edu/fatec/Porygon/repository/FormatoRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/FormatoRepository.java
@@ -1,0 +1,7 @@
+package edu.fatec.Porygon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import edu.fatec.Porygon.model.Formato;
+
+public interface FormatoRepository extends JpaRepository<Formato, Integer> {
+}

--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -56,9 +56,11 @@
                 </select>
             </div>
             <div class="col-md-6">
-                <label for="formato" class="form-label">Insira o tipo de arquivo de retorno da API</label>
-                <input type="text" class="form-control" id="formato" th:field="*{formato}" placeholder="Formato da API (JSON, XML, etc.)" required>
-            </div>
+                <label for="formato" class="form-label">Formato da API</label>
+                <select class="form-select" id="formato" th:field="*{formato.id}" required>
+                    <option th:each="formato : ${formatos}" th:value="${formato.id}" th:text="${formato.nome}"></option>
+                </select>
+            </div> 
         </div>
 
         <div class="row mb-3">


### PR DESCRIPTION
Objetivo: Adicionar a carga inicial de formatos padrão no banco de dados e garantir consistência na configuração de dados iniciais.

Criação do FormatoDataLoader:
> Implementada a classe FormatoDataLoader para carregar os formatos padrão (JSON, CSV, XML) no banco de dados durante a inicialização do sistema.
> Verificação implementada para garantir que os formatos sejam carregados apenas se não existirem registros previamente no banco, evitando duplicações.

Criação do FormatoRepository:
> Adicionado o repositório FormatoRepository para realizar operações de persistência da entidade Formato.

Estrutura da Entidade Formato:
> Definida a entidade Formato com os atributos id e nome, além dos métodos get e set correspondentes.

Atualização do Banco de Dados:
> Inseridos dados iniciais no banco para facilitar o cadastro e seleção de formatos nas APIs e Portais, garantindo que esses dados estejam disponíveis assim que a aplicação for inicializada.