### PR TITLE
chore/criado pasta config para os DDL que sobem quando a aplicação inicia

### DIFF
--- a/src/main/java/edu/fatec/Porygon/config/AgendadorDataLoader.java
+++ b/src/main/java/edu/fatec/Porygon/config/AgendadorDataLoader.java
@@ -1,5 +1,6 @@
-package edu.fatec.Porygon.model;
+package edu.fatec.Porygon.config;
 
+import edu.fatec.Porygon.model.Agendador;
 import edu.fatec.Porygon.repository.AgendadorRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -30,7 +31,7 @@ public class AgendadorDataLoader implements CommandLineRunner {
             agendadorRepository.save(semanal);
             agendadorRepository.save(mensal);
 
-            System.out.println("Agendadores padrão inseridos no banco de dados.");
+            // System.out.println("Agendadores padrão inseridos no banco de dados.");
         }
     }
 }

--- a/src/main/java/edu/fatec/Porygon/config/FormatoDataLoader.java
+++ b/src/main/java/edu/fatec/Porygon/config/FormatoDataLoader.java
@@ -1,5 +1,6 @@
-package edu.fatec.Porygon.model;
+package edu.fatec.Porygon.config;
 
+import edu.fatec.Porygon.model.Formato;
 import edu.fatec.Porygon.repository.FormatoRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
@@ -27,7 +28,7 @@ public class FormatoDataLoader implements CommandLineRunner {
             formatoRepository.save(csv);
             formatoRepository.save(xml);
 
-            System.out.println("Formatos padrão inseridos no banco de dados.");
+            // System.out.println("Formatos padrão inseridos no banco de dados.");
         }
     }
 }


### PR DESCRIPTION
Os arquivos que populam a tabela do Agendador e da tabela formato foram colocados em uma pasta diferente , já que esses não são entidades e sim um script para inserção de dados no banco quando a aplicação inicia.