### PR TITLE
PYG-3 PYG-37: Adicionando feature de editar as informações de APIs cadastrados

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/ApiController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/ApiController.java
@@ -32,21 +32,8 @@ public class ApiController {
     @GetMapping()
     public String mostrarFormularioCadastro(Model model) {
         Api novaApi = new Api();
-        novaApi.setAtivo(true); 
+        novaApi.setAtivo(true);
         model.addAttribute("api", novaApi);
-        model.addAttribute("apis", apiService.listarTodas());
-        model.addAttribute("agendadores", agendadorRepository.findAll());
-        model.addAttribute("formatos", formatoRepository.findAll());
-        model.addAttribute("tags", tagRepository.findAll());
-        return "api";
-    }
-
-    @GetMapping("/editar/{id}")
-    public String mostrarFormularioEdicao(@PathVariable("id") Integer id, Model model) {
-        Api api = apiService.buscarPorId(id)
-                .orElseThrow(() -> new IllegalArgumentException("ID inválido: " + id));
-
-        model.addAttribute("api", api);
         model.addAttribute("apis", apiService.listarTodas());
         model.addAttribute("agendadores", agendadorRepository.findAll());
         model.addAttribute("formatos", formatoRepository.findAll());
@@ -69,7 +56,7 @@ public class ApiController {
             return "api";
         }
     }
-    
+
     @PostMapping("/alterarStatus/{id}")
     public ResponseEntity<?> alterarStatus(@PathVariable Integer id, @RequestBody Map<String, Boolean> body) {
         boolean novoStatus = body.get("ativo");
@@ -80,8 +67,8 @@ public class ApiController {
     @GetMapping("/dados")
     public String listarApiDados(Model model) {
         List<Api> apis = apiService.listarTodas();
-        model.addAttribute("apis", apis); 
+        model.addAttribute("apis", apis);
         return "apiDados";
     }
-    
+
 }

--- a/src/main/java/edu/fatec/Porygon/controller/ApiController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/ApiController.java
@@ -41,6 +41,19 @@ public class ApiController {
         return "api";
     }
 
+    @GetMapping("/editar/{id}")
+    public String mostrarFormularioEdicao(@PathVariable("id") Integer id, Model model) {
+        Api api = apiService.buscarPorId(id)
+                .orElseThrow(() -> new IllegalArgumentException("ID inválido: " + id));
+
+        model.addAttribute("api", api);
+        model.addAttribute("apis", apiService.listarTodas());
+        model.addAttribute("agendadores", agendadorRepository.findAll());
+        model.addAttribute("formatos", formatoRepository.findAll());
+        model.addAttribute("tags", tagRepository.findAll());
+        return "api";
+    }
+
     @PostMapping("/salvar")
     public String salvarOuAtualizarApi(@ModelAttribute Api api, Model model) {
         try {

--- a/src/main/java/edu/fatec/Porygon/service/ApiService.java
+++ b/src/main/java/edu/fatec/Porygon/service/ApiService.java
@@ -23,20 +23,35 @@ public class ApiService {
         return apiRepository.findById(id);
     }
 
+    public boolean existsByNome(String nome) {
+        return apiRepository.existsByNome(nome);
+    }
+
+    public boolean existsByUrl(String url) {
+        return apiRepository.existsByUrl(url);
+    }
+
     public Api salvarOuAtualizar(Api api) {
-        if (apiRepository.existsByNome(api.getNome())) {
-            throw new IllegalArgumentException("Já existe uma API cadastrada com este nome.");
-        }
-        if (apiRepository.existsByUrl(api.getUrl())) {
-            throw new IllegalArgumentException("Já existe uma API cadastrada com esta URL.");
-        }
-        if (api.getId() == null) {
-            api.setDataCriacao(LocalDate.now());
-        } else {
+        if (api.getId() != null) {
             Api apiExistente = apiRepository.findById(api.getId())
                     .orElseThrow(() -> new IllegalArgumentException("ID inválido: " + api.getId()));
+
+            if (!api.getNome().equals(apiExistente.getNome()) && apiRepository.existsByNome(api.getNome())) {
+                throw new IllegalArgumentException("Já existe uma API cadastrada com este nome.");
+            }
+            if (!api.getUrl().equals(apiExistente.getUrl()) && apiRepository.existsByUrl(api.getUrl())) {
+                throw new IllegalArgumentException("Já existe uma API cadastrada com esta URL.");
+            }
             api.setDataCriacao(apiExistente.getDataCriacao());
-        } 
+        } else {
+            if (apiRepository.existsByNome(api.getNome())) {
+                throw new IllegalArgumentException("Já existe uma API cadastrada com este nome.");
+            }
+            if (apiRepository.existsByUrl(api.getUrl())) {
+                throw new IllegalArgumentException("Já existe uma API cadastrada com esta URL.");
+            }
+            api.setDataCriacao(LocalDate.now());
+        }
         return apiRepository.save(api);
     }
 
@@ -49,5 +64,4 @@ public class ApiService {
         }
         return null;
     }
-
 }

--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -50,17 +50,18 @@
         <h4 class="mb-4 text-center" th:text="${api.id} != null ? 'Editar API' : 'Cadastro de API'"></h4>
         <form th:action="@{/apis/salvar}" th:object="${api}" method="post">
             <input type="hidden" th:field="*{id}">
+            <input type="hidden" name="isEdit" th:value="${api.id != null}">
 
             <div class="row mb-3">
                 <div class="col-md-6">
                     <label for="nome" class="form-label">Nome</label>
                     <input type="text" class="form-control" id="nome" th:field="*{nome}"
-                        placeholder="Digite o nome da API" required>
+                           placeholder="Digite o nome da API" required>
                 </div>
                 <div class="col-md-6">
                     <label for="url" class="form-label">URL</label>
                     <input type="text" class="form-control" id="url" th:field="*{url}" placeholder="Insira a URL da API"
-                        required>
+                           required>
                 </div>
             </div>
 
@@ -69,7 +70,7 @@
                     <label for="agendador" class="form-label">Agendador</label>
                     <select class="form-select" id="agendador" th:field="*{agendador.id}">
                         <option th:each="agendador : ${agendadores}" th:value="${agendador.id}"
-                            th:text="${agendador.tipo}"></option>
+                                th:text="${agendador.tipo}"></option>
                     </select>
                 </div>
                 <div class="col-md-6">
@@ -84,20 +85,19 @@
                 <div class="col-md-6 mb-3">
                     <label for="descricao" class="form-label">Descrição</label>
                     <textarea class="form-control" id="descricao" th:field="*{descricao}" placeholder="Descrição da API"
-                        rows="4" required></textarea>
+                              rows="4" required></textarea>
                 </div>
 
                 <div class="col-md-6">
                     <label for="tags" class="form-label">Tags</label>
-                    <select id="tags" class="form-select" multiple th:disabled="${tags.size() == 0}" size="4"
-                        style="font-size: 16px;">
+                    <select id="tags" class="form-select" multiple th:field="*{tags}" th:disabled="${tags.size() == 0}" size="4"
+                            style="font-size: 16px;">
                         <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"></option>
                     </select>
                     <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas
                         opções.</small>
                 </div>
             </div>
-
 
             <div class="row mb-3">
                 <div class="col-md-12">

--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link href="https://bootswatch.com/5/cerulean/bootstrap.min.css" rel="stylesheet">
     <style>
-        body {
+        body{
             font-size: 14px;
         }
     </style>
@@ -14,17 +14,18 @@
 
 <body>
 <nav class="navbar bg-dark border-bottom border-body" data-bs-theme="dark">
-    <a class="navbar-brand" href="#" style="margin-left: 10px;"></a>
+    <a class="navbar-brand" href="#" style="margin-left: 10px;">
+    </a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
             aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="navbar-nav">
-            <li class="nav-item">
+            <li class="nav-item ">
                 <a class="nav-link" th:href="@{/index}">Consulta de Notícias</a>
             </li>
-            <li class="nav-item">
+            <li class="nav-item ">
                 <a class="nav-link" th:href="@{/apis/dados}">Consulta de Dados das Api's</a>
             </li>
             <li class="nav-item">
@@ -49,7 +50,6 @@
     <h4 class="mb-4 text-center" th:text="${api.id} != null ? 'Editar API' : 'Cadastro de API'"></h4>
     <form th:action="@{/apis/salvar}" th:object="${api}" method="post">
         <input type="hidden" th:field="*{id}">
-        <input type="hidden" name="isEdit" th:value="${api.id != null}">
 
         <div class="row mb-3">
             <div class="col-md-6">
@@ -89,7 +89,7 @@
 
             <div class="col-md-6">
                 <label for="tags" class="form-label">Tags</label>
-                <select id="tags" class="form-select" multiple th:field="*{tags}" th:disabled="${tags.size() == 0}" size="4"
+                <select id="tags" class="form-select" multiple th:disabled="${tags.size() == 0}" size="4"
                         style="font-size: 16px;">
                     <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"></option>
                 </select>
@@ -97,6 +97,7 @@
                     opções.</small>
             </div>
         </div>
+
 
         <div class="row mb-3">
             <div class="col-md-12">
@@ -140,6 +141,14 @@
                 <td th:text="${api.descricao}"></td>
                 <td th:text="${api.url}"></td>
                 <td th:text="'Inativo'">Inativo</td>
+                <!-- <td>
+        <span th:if="${#lists.isEmpty(portal.tags)}">Nenhuma Tag cadastrada</span>
+        <span th:each="tag, iterStat : ${portal.tags}">
+            <span th:text="${tag.nome}"></span>
+            <span th:if="${!iterStat.last}">, </span>
+
+        </span>
+    </td>       -->
                 <td th:text="${api.agendador != null ? api.agendador.tipo : 'Sem Agendador'}"></td>
                 <td>
                     <div class="form-check form-switch">
@@ -157,6 +166,7 @@
         </table>
     </div>
 </div>
+
 
 <script>
     function toggleStatus(checkbox) {

--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -6,207 +6,197 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
     <link href="https://bootswatch.com/5/cerulean/bootstrap.min.css" rel="stylesheet">
     <style>
-        body{
+        body {
             font-size: 14px;
         }
     </style>
 </head>
 
 <body>
-    <nav class="navbar bg-dark border-bottom border-body" data-bs-theme="dark">
-        <a class="navbar-brand" href="#" style="margin-left: 10px;">
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+<nav class="navbar bg-dark border-bottom border-body" data-bs-theme="dark">
+    <a class="navbar-brand" href="#" style="margin-left: 10px;"></a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
             aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav">
-                <li class="nav-item ">
-                    <a class="nav-link" th:href="@{/index}">Consulta de Notícias</a>
-                </li>
-                <li class="nav-item ">
-                    <a class="nav-link" th:href="@{/apis/dados}">Consulta de Dados das Api's</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" th:href="@{/portais}">Cadastro de Portal</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" th:href="@{/apis}">Cadastro de API<span class="sr-only">(atual)</span></a>
-                </li>
-            </ul>
-        </div>
-    </nav>
-
-    <div class="container">
-        <div th:if="${erro}" class="alert alert-danger alert-dismissible fade show" role="alert"
-            style="margin: 20px auto;">
-            <span th:text="${erro}">Erro ao cadastrar API.</span>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" th:href="@{/index}">Consulta de Notícias</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" th:href="@{/apis/dados}">Consulta de Dados das Api's</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" th:href="@{/portais}">Cadastro de Portal</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" th:href="@{/apis}">Cadastro de API<span class="sr-only">(atual)</span></a>
+            </li>
+        </ul>
     </div>
+</nav>
 
-    <div class="container mt-5">
-        <h4 class="mb-4 text-center" th:text="${api.id} != null ? 'Editar API' : 'Cadastro de API'"></h4>
-        <form th:action="@{/apis/salvar}" th:object="${api}" method="post">
-            <input type="hidden" th:field="*{id}">
-            <input type="hidden" name="isEdit" th:value="${api.id != null}">
+<div class="container">
+    <div th:if="${erro}" class="alert alert-danger alert-dismissible fade show" role="alert"
+         style="margin: 20px auto;">
+        <span th:text="${erro}">Erro ao cadastrar API.</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+</div>
 
-            <div class="row mb-3">
-                <div class="col-md-6">
-                    <label for="nome" class="form-label">Nome</label>
-                    <input type="text" class="form-control" id="nome" th:field="*{nome}"
-                           placeholder="Digite o nome da API" required>
-                </div>
-                <div class="col-md-6">
-                    <label for="url" class="form-label">URL</label>
-                    <input type="text" class="form-control" id="url" th:field="*{url}" placeholder="Insira a URL da API"
-                           required>
-                </div>
+<div class="container mt-5">
+    <h4 class="mb-4 text-center" th:text="${api.id} != null ? 'Editar API' : 'Cadastro de API'"></h4>
+    <form th:action="@{/apis/salvar}" th:object="${api}" method="post">
+        <input type="hidden" th:field="*{id}">
+        <input type="hidden" name="isEdit" th:value="${api.id != null}">
+
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="nome" class="form-label">Nome</label>
+                <input type="text" class="form-control" id="nome" th:field="*{nome}"
+                       placeholder="Digite o nome da API" required>
+            </div>
+            <div class="col-md-6">
+                <label for="url" class="form-label">URL</label>
+                <input type="text" class="form-control" id="url" th:field="*{url}" placeholder="Insira a URL da API"
+                       required>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label for="agendador" class="form-label">Agendador</label>
+                <select class="form-select" id="agendador" th:field="*{agendador.id}">
+                    <option th:each="agendador : ${agendadores}" th:value="${agendador.id}"
+                            th:text="${agendador.tipo}"></option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label for="formato" class="form-label">Formato da API</label>
+                <select class="form-select" id="formato" th:field="*{formato.id}" required>
+                    <option th:each="formato : ${formatos}" th:value="${formato.id}" th:text="${formato.nome}"></option>
+                </select>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="col-md-6 mb-3">
+                <label for="descricao" class="form-label">Descrição</label>
+                <textarea class="form-control" id="descricao" th:field="*{descricao}" placeholder="Descrição da API"
+                          rows="4" required></textarea>
             </div>
 
-            <div class="row mb-3">
-                <div class="col-md-6">
-                    <label for="agendador" class="form-label">Agendador</label>
-                    <select class="form-select" id="agendador" th:field="*{agendador.id}">
-                        <option th:each="agendador : ${agendadores}" th:value="${agendador.id}"
-                                th:text="${agendador.tipo}"></option>
-                    </select>
-                </div>
-                <div class="col-md-6">
-                    <label for="formato" class="form-label">Formato da API</label>
-                    <select class="form-select" id="formato" th:field="*{formato.id}" required>
-                        <option th:each="formato : ${formatos}" th:value="${formato.id}" th:text="${formato.nome}"></option>
-                    </select>
+            <div class="col-md-6">
+                <label for="tags" class="form-label">Tags</label>
+                <select id="tags" class="form-select" multiple th:field="*{tags}" th:disabled="${tags.size() == 0}" size="4"
+                        style="font-size: 16px;">
+                    <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"></option>
+                </select>
+                <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas
+                    opções.</small>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="col-md-12">
+                <label class="form-label">
+                    Para que a API esteja ativa, deixe o checkbox "Ativa" marcado.
+                </label>
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="ativo" th:field="*{ativo}" checked>
+                    <label class="form-check-label" for="ativo"><strong>Ativa</strong></label>
                 </div>
             </div>
+        </div>
 
-            <div class="row mb-3">
-                <div class="col-md-6 mb-3">
-                    <label for="descricao" class="form-label">Descrição</label>
-                    <textarea class="form-control" id="descricao" th:field="*{descricao}" placeholder="Descrição da API"
-                              rows="4" required></textarea>
-                </div>
+        <div class="d-grid gap-2 col-2 mx-auto">
+            <button type="submit" class="btn btn-primary">Salvar</button>
+        </div>
+    </form>
+</div>
 
-                <div class="col-md-6">
-                    <label for="tags" class="form-label">Tags</label>
-                    <select id="tags" class="form-select" multiple th:field="*{tags}" th:disabled="${tags.size() == 0}" size="4"
-                            style="font-size: 16px;">
-                        <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"></option>
-                    </select>
-                    <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas
-                        opções.</small>
-                </div>
-            </div>
+<br>
 
-            <div class="row mb-3">
-                <div class="col-md-12">
-                    <label class="form-label">
-                        Para que a API esteja ativa, deixe o checkbox "Ativa" marcado.
-                    </label>
-                    <div class="form-check">
-                        <input type="checkbox" class="form-check-input" id="ativo" th:field="*{ativo}" checked>
-                        <label class="form-check-label" for="ativo"><strong>Ativa</strong></label>
+<div class="container mt-5">
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Nome</th>
+                <th>Descrição</th>
+                <th>URL</th>
+                <th>Tags</th>
+                <th>Agendador</th>
+                <th style="width: 100px; text-align: left;">Status</th>
+                <th>Ações</th>
+            </tr>
+            </thead>
+            <tbody class="table-group-divider">
+            <tr th:each="api : ${apis}">
+                <td th:text="${api.id}"></td>
+                <td th:text="${api.nome}"></td>
+                <td th:text="${api.descricao}"></td>
+                <td th:text="${api.url}"></td>
+                <td th:text="'Inativo'">Inativo</td>
+                <td th:text="${api.agendador != null ? api.agendador.tipo : 'Sem Agendador'}"></td>
+                <td>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" th:checked="${api.ativo}"
+                               th:attr="data-id=${api.id}" onchange="toggleStatus(this)">
+                        <label class="form-check-label" style="min-width: 75px;"
+                               th:text="${api.ativo ? 'Ativa' : 'Desativa'}"></label>
                     </div>
-                </div>
-            </div>
-
-            <div class="d-grid gap-2 col-2 mx-auto">
-                <button type="submit" class="btn btn-primary">Salvar</button>
-            </div>
-        </form>
+                </td>
+                <td>
+                    <a class="btn btn-info" th:href="@{/apis/editar/{id}(id=${api.id})}">Editar</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
     </div>
+</div>
 
-    <br>
+<script>
+    function toggleStatus(checkbox) {
+        const apiId = checkbox.getAttribute('data-id');
+        const isActive = checkbox.checked;
+        const label = checkbox.nextElementSibling;
 
-    <div class="container mt-5">
-        <div class="table-responsive">
-            <table class="table table-striped table-hover">
-                <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Nome</th>
-                        <th>Descrição</th>
-                        <th>URL</th>
-                        <th>Tags</th>
-                        <th>Agendador</th>
-                        <th style="width: 100px; text-align: left;">Status</th>
-                        <th>Ações</th>
-                    </tr>
-                </thead>
-                <tbody class="table-group-divider">
-                    <tr th:each="api : ${apis}">
-                        <td th:text="${api.id}"></td>
-                        <td th:text="${api.nome}"></td>
-                        <td th:text="${api.descricao}"></td>
-                        <td th:text="${api.url}"></td>
-                        <td th:text="'Inativo'">Inativo</td>
-                        <!-- <td>
-                <span th:if="${#lists.isEmpty(portal.tags)}">Nenhuma Tag cadastrada</span>
-                <span th:each="tag, iterStat : ${portal.tags}">
-                    <span th:text="${tag.nome}"></span>
-                    <span th:if="${!iterStat.last}">, </span>
+        label.textContent = isActive ? 'Ativa' : 'Desativa';
 
-                </span>
-            </td>       -->
-                        <td th:text="${api.agendador != null ? api.agendador.tipo : 'Sem Agendador'}"></td>
-                        <td>
-                            <div class="form-check form-switch">
-                                <input class="form-check-input" type="checkbox" th:checked="${api.ativo}"
-                                    th:attr="data-id=${api.id}" onchange="toggleStatus(this)">
-                                <label class="form-check-label" style="min-width: 75px;"
-                                    th:text="${api.ativo ? 'Ativa' : 'Desativa'}"></label>
-                            </div>
-                        </td>
-                        <td>
-                            <a class="btn btn-info" th:href="@{/apis/editar/{id}(id=${api.id})}">Editar</a>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </div>
-
-
-    <script>
-        function toggleStatus(checkbox) {
-            const apiId = checkbox.getAttribute('data-id');
-            const isActive = checkbox.checked;
-            const label = checkbox.nextElementSibling;
-
-            label.textContent = isActive ? 'Ativa' : 'Desativa';
-
-            fetch(`/apis/alterarStatus/${apiId}`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ ativo: isActive })
-            })
-                .then(response => {
-                    if (!response.ok) {
-                        alert("Erro ao alterar o status!");
-                        checkbox.checked = !isActive;
-                        label.textContent = !isActive ? 'Ativa' : 'Desativa';
-                    }
-                })
-                .catch(error => {
-                    alert("Erro na comunicação com o servidor!");
+        fetch(`/apis/alterarStatus/${apiId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ ativo: isActive })
+        })
+            .then(response => {
+                if (!response.ok) {
+                    alert("Erro ao alterar o status!");
                     checkbox.checked = !isActive;
                     label.textContent = !isActive ? 'Ativa' : 'Desativa';
-                });
+                }
+            })
+            .catch(error => {
+                alert("Erro na comunicação com o servidor!");
+                checkbox.checked = !isActive;
+                label.textContent = !isActive ? 'Ativa' : 'Desativa';
+            });
+    }
+
+    setTimeout(function () {
+        const alert = document.querySelector('.alert');
+        if (alert) {
+            alert.classList.remove('show');
+            alert.classList.add('fade');
         }
+    }, 5000);
+</script>
 
-        setTimeout(function () {
-            const alert = document.querySelector('.alert');
-            if (alert) {
-                alert.classList.remove('show');
-                alert.classList.add('fade');
-            }
-        }, 5000);
-    </script>
-
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Adicionei essa feature me baseando na mesma edição que já temos na tela de portais, tive que realizar um fix a mais na lógica de verificação de duplicidade, pois:

- Ao editar uma API, a lógica verificava se o nome ou a url já existiam no banco, sem considerar se esses valores eram diferentes dos valores atuais da API que estava sendo editada.
- Isso causava um falso positivo de duplicidade, pois a verificação não diferenciava entre os campos que foram alterados e os que não foram.

Tive esse probleminha ao implementar a verificação nos portais também, aí aqui foi mais simples de resolver..
Resumindo, do jeito que estava, só seria possível realizar edições se o nome e URL da api fossem alteradas juntas.