### PR TITLE
PYG-17 PYG-44 feat(index): adiciona exibição no front de noticias filtradas por data

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
@@ -2,24 +2,34 @@ package edu.fatec.Porygon.controller;
 
 import edu.fatec.Porygon.model.Noticia;
 import edu.fatec.Porygon.repository.NoticiaRepository;
+// import edu.fatec.Porygon.service.NoticiaService;
 
 import java.util.List;
 import java.util.Optional;
 
+// import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+// import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+// import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+// import ch.qos.logback.classic.Logger;
 
 @Controller
 public class NoticiaController {
 
     @Autowired
     private NoticiaRepository noticiaRepository;
+    // @Autowired
+    // private NoticiaService noticiaService;
+
+    // private static final Logger logger = (Logger) LoggerFactory.getLogger(NoticiaController.class);
 
     @GetMapping("/index")
     public String listarNoticias(Model model) {
@@ -34,6 +44,17 @@ public class NoticiaController {
         return noticiaOptional.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
 
+    // @GetMapping("/noticias")
+    // @ResponseBody
+    // public List<Noticia> listarNoticiasPorData(
+    //         @RequestParam("dataInicio") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) java.util.Date dataInicio,
+    //         @RequestParam("dataFim") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) java.util.Date dataFim) {
+
+    //     logger.info("Data Início: " + dataInicio);
+    //     logger.info("Data Fim: " + dataFim);
+
+    //     return noticiaService.listarNoticiasPorData(dataInicio, dataFim);
+    // }
 }
 
 

--- a/src/main/java/edu/fatec/Porygon/repository/NoticiaRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/NoticiaRepository.java
@@ -1,10 +1,13 @@
 package edu.fatec.Porygon.repository;
 
 import edu.fatec.Porygon.model.Noticia;
+// import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NoticiaRepository extends JpaRepository<Noticia, Integer> {
     boolean existsByHref(String href);
+
+    // List<Noticia> acharDataEntre(java.util.Date dataInicio, java.util.Date dataFim); // Método de filtro de consulta: data}
 }

--- a/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
+++ b/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
@@ -14,5 +14,9 @@ public class NoticiaService {
 
     public List<Noticia> listarNoticias() {
         return noticiaRepository.findAll();
-    }    
+    }
+    
+    // public List<Noticia> listarNoticiasPorData(java.util.Date dataInicio, java.util.Date dataFim) {
+    //     return noticiaRepository.acharDataEntre(dataInicio, dataFim);
+    // }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -47,15 +47,15 @@
         <h4 class="mb-4 text-center">Portal de Consultas</h4>
 
         <!-- Formulário de Filtros (Desativado) -->
-        <form>
+        <form id="filterForm">
             <div class="row mb-3">
                 <div class="col">
                     <label for="dataInicio" class="form-label">Data Início</label>
-                    <input type="date" class="form-control" id="dataInicio" disabled>
+                    <input type="date" class="form-control" id="dataInicio">
                 </div>
                 <div class="col">
                     <label for="dataFim" class="form-label">Data Fim</label>
-                    <input type="date" class="form-control" id="dataFim" disabled>
+                    <input type="date" class="form-control" id="dataFim">
                 </div>
             </div>
 
@@ -76,7 +76,7 @@
             </div>
 
             <div class="d-grid gap-2 col-2 mx-auto">
-                <button type="button" class="btn btn-primary" disabled>Consultar</button>
+                <button type="button" class="btn btn-primary" id="consultar">Consultar</button>
             </div>
         </form>
 
@@ -152,6 +152,30 @@
                 })
                 .catch(error => console.error('Erro ao carregar os detalhes da notícia:', error));
         }
+        document.getElementById('consultar').addEventListener('click', function () {
+            const dataInicio = document.getElementById('dataInicio').value;
+            const dataFim = document.getElementById('dataFim').value;
+
+            fetch(`/noticias?dataInicio=${dataInicio}&dataFim=${dataFim}`)
+                .then(response => response.json())
+                .then(data => {
+                    // Atualize a tabela de notícias com os dados filtrados
+                    const tbody = document.querySelector('tbody.table-group-divider');
+                    tbody.innerHTML = '';
+                    data.forEach(noticia => {
+                        const row = document.createElement('tr');
+                        row.innerHTML = `
+                            <td>Inativo</td>
+                            <td>${noticia.titulo}</td>
+                            <td>Inativo</td>
+                            <td>${new Date(noticia.data).toLocaleDateString('pt-BR')}</td>
+                            <td><button class="btn btn-info" onclick="abrirModal(${noticia.id})">Abrir</button></td>
+                            `;
+                        tbody.appendChild(row);
+                    });
+                })
+                .catch(error => console.error('Erro ao carregar as notícias:', error));
+        });
     </script>
 
     <!-- Bootstrap JS e dependências -->


### PR DESCRIPTION
Fiz a task de Exibir Notícias Filtradas por Data - FrontEnd. Minhas modificações estão no no arquivo index.html.

Deixei comentados os testes básicos que fiz com o back para saber se está realmente voltando a lista de notícias filtradas por data (arquivos NoticiaService, NoticiaController, NoticiaRepository.) Nenhuma validação foi feita nesse teste do back, pois as tasks abaixo ficarão responsáveis por isso:

A task PYG-17 PYG-39 precisa implementar a lógica backend para consultar notícias filtradas pelo intervalo de datas selecionado, pode usar o que eu deixei comentado como base, mas verifica se é a melhor escolha. 

Na task PYG-17 PYG-42, que é para implementar a interface das datas, aqui já está implementada. Eu indico participar na integração do front quando o back estiver pronto, e aí fazer possíveis ajustes no front.

Na task PYG-17 PYG-43, será necessário implementar a validação do intervalo de datas selecionado - BackEnd e FrontEnd. Isso não foi feito na minha task, precisa colocar a validação da data inicial ser sempre menor ou igual a data final e se o retorno das notícias está correto com as datas selecionadas. 