### PR TITLE
PYG-3/PYG-52/Feat/Switch-Case

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/ApiDadosController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/ApiDadosController.java
@@ -23,15 +23,29 @@ public class ApiDadosController {
         if (apiDadosOptional.isPresent()) {
             ApiDados apiDados = apiDadosOptional.get();
             String conteudo = apiDados.getConteudo();
-            String descricao = apiDados.getDescricao();
 
-            String tipo = descricao.toLowerCase();
+            Integer formatoId = apiDados.getApi().getFormato().getId();  // < Pegando o formato pela api
+
+            String tipo = getTipoFormato(formatoId);
             String conteudoFormatado = formatarConteudo(conteudo, tipo);
 
             return ResponseEntity.ok(conteudoFormatado);
         }
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Dados não encontrados");
+    }
+
+    private String getTipoFormato(Integer formatoId) {
+        switch (formatoId) {
+            case 1:
+                return "json";
+            case 2:
+                return "csv";
+            case 3:
+                return "xml";
+            default:
+                return "desconhecido";
+        }
     }
 
     private String formatarConteudo(String conteudo, String tipo) {

--- a/src/main/java/edu/fatec/Porygon/controller/ApiDadosController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/ApiDadosController.java
@@ -1,0 +1,60 @@
+package edu.fatec.Porygon.controller;
+
+import edu.fatec.Porygon.model.ApiDados;
+import edu.fatec.Porygon.repository.ApiDadosRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/dados")
+public class ApiDadosController {
+
+    @Autowired
+    private ApiDadosRepository apiDadosRepository;
+
+    @GetMapping("/{id}")
+    public ResponseEntity<String> abrirDados(@PathVariable Integer id) {
+        Optional<ApiDados> apiDadosOptional = apiDadosRepository.findById(id);
+
+        if (apiDadosOptional.isPresent()) {
+            ApiDados apiDados = apiDadosOptional.get();
+            String conteudo = apiDados.getConteudo();
+            String descricao = apiDados.getDescricao();
+
+            String tipo = descricao.toLowerCase();
+            String conteudoFormatado = formatarConteudo(conteudo, tipo);
+
+            return ResponseEntity.ok(conteudoFormatado);
+        }
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Dados não encontrados");
+    }
+
+    private String formatarConteudo(String conteudo, String tipo) {
+        switch (tipo) {
+            case "json":
+                return conteudo
+                        .replace("{", "\n{")
+                        .replace("}", "}\n")
+                        .replace("[", "\n[")
+                        .replace("]", "]\n")
+                        .replace(",", ",\n")
+                        .replace(":", ": ");
+            case "xml":
+                return conteudo
+                        .replace("<", "\n<")
+                        .replace(">", ">\n")
+                        .replace("<rate>", "\n<rate>")
+                        .replace("</rate>", "</rate>\n")
+                        .replace("\n\n", "\n");
+            case "csv":
+                return conteudo.replace(";", ";\n");
+            default:
+                return conteudo;
+        }
+    }
+}

--- a/src/main/java/edu/fatec/Porygon/model/ApiDados.java
+++ b/src/main/java/edu/fatec/Porygon/model/ApiDados.java
@@ -11,40 +11,33 @@ public class ApiDados {
 
     @Column(columnDefinition = "TEXT")
     private String conteudo;
-    
     private String descricao;
 
     @ManyToOne
     @JoinColumn(name = "api_id")
-    private Api api;
 
+    private Api api;
     public String getConteudo() {
         return conteudo;
     }
-
     public void setConteudo(String conteudo) {
         this.conteudo = conteudo;
     }
-
     public String getDescricao() {
         return descricao;
     }
     public void setDescricao(String descricao) {
         this.descricao = descricao;
     }
-
     public Api getApi() {
         return api;
     }
-
     public void setApi(Api api) {
         this.api = api;
     }
-
     public Integer getId() {
         return id;
     }
-
     public void setId(Integer id) {
         this.id = id;
     }

--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -77,6 +77,8 @@
                     <select class="form-select" id="formato" th:field="*{formato.id}" required>
                         <option th:each="formato : ${formatos}" th:value="${formato.id}" th:text="${formato.nome}"></option>
                     </select>
+                    <small class="form-text text-muted">Selecione o tipo de arquivo retornado pela API REST corretamente.
+                        A seleção incorreta pode desconfigurarar a leitura.</small>
                 </div>
             </div>
 

--- a/src/main/resources/templates/apiDados.html
+++ b/src/main/resources/templates/apiDados.html
@@ -10,109 +10,146 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://bootswatch.com/5/cerulean/bootstrap.min.css" rel="stylesheet">
     <style>
-        body{
+        body {
             font-size: 14px;
         }
     </style>
 </head>
 
 <body>
-    <!-- Navbar no index.html -->
-    <nav class="navbar bg-dark border-bottom border-body" data-bs-theme="dark">
-        <a class="navbar-brand" href="#" style="margin-left: 10px;">
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+<!-- Navbar no index.html -->
+<nav class="navbar bg-dark border-bottom border-body" data-bs-theme="dark">
+    <a class="navbar-brand" href="#" style="margin-left: 10px;">
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
             aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav">
-                <li class="nav-item">
-                    <a class="nav-link" th:href="@{/index}">Consulta de Notícias</a>
-                </li>
-                <li class="nav-item ">
-                    <a class="nav-link" th:href="@{/apis/dados}">Consulta de Dados das Api's<span class="sr-only">(atual)</span></a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" th:href="@{/portais}">Cadastro de Portal</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" th:href="@{/apis}">Cadastro de API</a>
-                </li>
-            </ul>
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <a class="nav-link" th:href="@{/index}">Consulta de Notícias</a>
+            </li>
+            <li class="nav-item ">
+                <a class="nav-link" th:href="@{/apis/dados}">Consulta de Dados das Api's<span class="sr-only">(atual)</span></a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" th:href="@{/portais}">Cadastro de Portal</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" th:href="@{/apis}">Cadastro de API</a>
+            </li>
+        </ul>
+    </div>
+</nav>
+
+<div class="container mt-5">
+    <h4 class="mb-4 text-center">Portal de Consultas</h4>
+
+    <!-- Formulário de Filtros (Desativado) -->
+    <form>
+        <div class="row mb-3">
+            <div class="col">
+                <label for="dataInicio" class="form-label">Data Início</label>
+                <input type="date" class="form-control" id="dataInicio" disabled>
+            </div>
+            <div class="col">
+                <label for="dataFim" class="form-label">Data Fim</label>
+                <input type="date" class="form-control" id="dataFim" disabled>
+            </div>
         </div>
-    </nav>
 
-    <div class="container mt-5">
-        <h4 class="mb-4 text-center">Portal de Consultas</h4>
+        <div class="mb-3">
+            <label for="tags" class="form-label">Tags</label>
+            <select id="tags" class="form-select" multiple disabled>
+                <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"></option>
+            </select>
+            <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas
+                opções.</small>
+        </div>
 
-        <!-- Formulário de Filtros (Desativado) -->
-        <form>
-            <div class="row mb-3">
-                <div class="col">
-                    <label for="dataInicio" class="form-label">Data Início</label>
-                    <input type="date" class="form-control" id="dataInicio" disabled>
-                </div>
-                <div class="col">
-                    <label for="dataFim" class="form-label">Data Fim</label>
-                    <input type="date" class="form-control" id="dataFim" disabled>
-                </div>
-            </div>
+        <div class="mb-3">
+            <label for="palavraChave" class="form-label">Palavras no Conteúdo</label>
+            <input type="text" class="form-control" id="palavraChave"
+                   placeholder="Digite palavras separadas por vírgula" disabled>
+            <small class="form-text text-muted">Exemplo: cavalo, cachorro</small>
+        </div>
 
-            <div class="mb-3">
-                <label for="tags" class="form-label">Tags</label>
-                <select id="tags" class="form-select" multiple disabled>
-                    <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"></option>
-                </select>
-                <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas
-                    opções.</small>
-            </div>
+        <div class="d-grid gap-2 col-2 mx-auto">
+            <button type="button" class="btn btn-primary" disabled>Consultar</button>
+        </div>
+    </form>
 
-            <div class="mb-3">
-                <label for="palavraChave" class="form-label">Palavras no Conteúdo</label>
-                <input type="text" class="form-control" id="palavraChave"
-                    placeholder="Digite palavras separadas por vírgula" disabled>
-                <small class="form-text text-muted">Exemplo: cavalo, cachorro</small>
-            </div>
-
-            <div class="d-grid gap-2 col-2 mx-auto">
-                <button type="button" class="btn btn-primary" disabled>Consultar</button>
-            </div>
-        </form>
-
-        <!-- Lista de Ddos das Api's -->
-        <div class="mt-5">
-            <h4 class="mb-4 text-center">Lista de Dados das Api's</h4>
-            <div class="table-responsive">
-                <table class="table table-striped table-hover">
+    <!-- Lista de Dados das Api's -->
+    <div class="mt-5">
+        <h4 class="mb-4 text-center">Lista de Dados das Api's</h4>
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
                 <thead>
-                    <tr>
-                        <th>Nome</th>
-                        <th>Tags</th>
-                        <th>Descrição</th>
-                        <th>Ação</th>
-                    </tr>
+                <tr>
+                    <th>Nome</th>
+                    <th>Tags</th>
+                    <th>Descrição</th>
+                    <th>Ação</th>
+                </tr>
                 </thead>
                 <tbody>
-                    <tr th:each="api : ${apis}">
-                        <td th:text="${api.nome}"></td>
-                        <td th:text="'Inativo'"></td>
-                        <td>
-                            <span th:if="${api.apiDadosList.size() > 0}"
-                                th:text="${api.apiDadosList[0].descricao}"></span>
-                            <span th:if="${api.apiDadosList.size() == 0}">Sem dados disponíveis</span>
-                        </td>
-                        <td>
-                            <button class="btn btn-primary" disabled>Abrir</button> 
-                        </td>
-                    </tr>
+                <tr th:each="api : ${apis}">
+                    <td th:text="${api.nome}"></td>
+                    <td th:text="'Inativo'"></td>
+                    <td>
+                                <span th:if="${api.apiDadosList.size() > 0}"
+                                      th:text="${api.apiDadosList[0].descricao}"></span>
+                        <span th:if="${api.apiDadosList.size() == 0}">Sem dados disponíveis</span>
+                    </td>
+                    <td>
+                        <!-- Ativar o botão e passar o ID correto da API -->
+                        <button class="btn btn-primary" th:attr="data-id=${api.id}" onclick="abrirModal(this)">Abrir</button>
+                    </td>
+                </tr>
                 </tbody>
             </table>
         </div>
     </div>
 
+    <!-- Modal para exibir os dados -->
+    <div class="modal fade" id="apiModal" tabindex="-1" aria-labelledby="apiModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="apiModalLabel">Dados da API</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <pre id="conteudoApi"></pre>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Bootstrap JS e dependências -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+
+    <script>
+        function abrirModal(button) {
+            var apiId = button.getAttribute('data-id');
+
+            fetch(`/api/dados/${apiId}`)
+                .then(response => response.text())
+                .then(data => {
+                    document.getElementById('conteudoApi').textContent = data;
+                    var modal = new bootstrap.Modal(document.getElementById('apiModal'));
+                    modal.show();
+                })
+                .catch(error => {
+                    console.error('Erro ao buscar os dados da API:', error);
+                    document.getElementById('conteudoApi').textContent = 'Erro ao carregar os dados.';
+                });
+        }
+    </script>
 </body>
 
 </html>

--- a/src/main/resources/templates/apiDados.html
+++ b/src/main/resources/templates/apiDados.html
@@ -44,7 +44,7 @@
 </nav>
 
 <div class="container mt-5">
-    <h4 class="mb-4 text-center">Portal de Consultas</h4>
+    <h4 class="mb-4 text-center">Consulta de API`s</h4>
 
     <!-- Formulário de Filtros (Desativado) -->
     <form>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -44,7 +44,7 @@
     </nav>
 
     <div class="container mt-5">
-        <h4 class="mb-4 text-center">Portal de Consultas</h4>
+        <h4 class="mb-4 text-center">Consulta de Notícias</h4>
 
         <!-- Formulário de Filtros (Desativado) -->
         <form>


### PR DESCRIPTION
Criar um switch case para os tipos de arquivo. 
Por exemplo: CSV, mostrar no front uma tabela, convertendo os ; em células ou linhas. 
Não é necessário manipular ou converter os dados. 
Utilizar o botão “Abrir” da lista de APIs salvas no banco para mostrar essa edição. (FrontEnd, BackEnd e banco)

Os tipos de arquivos estão sendo salvos como:
1 - JSON;
2 - CSV;
3 - XML.

o switch, pega esse ID e arruma conforme o tipo, caso seja selecionado um tipo diferente do arquivo (Ex: é json, mas foi salvo como xml) não vai ser mostrado corretamente.