### PR TITLE
PYG-81 feat(banco): Criação tabela jornalista para armazenamento de nomes

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
@@ -2,34 +2,23 @@ package edu.fatec.Porygon.controller;
 
 import edu.fatec.Porygon.model.Noticia;
 import edu.fatec.Porygon.repository.NoticiaRepository;
-// import edu.fatec.Porygon.service.NoticiaService;
-
 import java.util.List;
 import java.util.Optional;
-
-// import org.slf4j.LoggerFactory;
+import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
-// import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-// import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-// import ch.qos.logback.classic.Logger;
 
 @Controller
 public class NoticiaController {
 
     @Autowired
     private NoticiaRepository noticiaRepository;
-    // @Autowired
-    // private NoticiaService noticiaService;
-
-    // private static final Logger logger = (Logger) LoggerFactory.getLogger(NoticiaController.class);
 
     @GetMapping("/index")
     public String listarNoticias(Model model) {
@@ -37,24 +26,20 @@ public class NoticiaController {
         model.addAttribute("noticias", noticias);
         return "index";
     }
+
     @GetMapping("/noticias/detalhe/{id}")
     @ResponseBody
     public ResponseEntity<Noticia> detalheNoticiaJson(@PathVariable Integer id) {
         Optional<Noticia> noticiaOptional = noticiaRepository.findById(id);
-        return noticiaOptional.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+        
+        if (noticiaOptional.isPresent()) {
+            Noticia noticia = noticiaOptional.get();
+            if (noticia.getJornalista() != null) {
+                Hibernate.initialize(noticia.getJornalista());
+            }
+            return ResponseEntity.ok(noticia);
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
     }
-
-    // @GetMapping("/noticias")
-    // @ResponseBody
-    // public List<Noticia> listarNoticiasPorData(
-    //         @RequestParam("dataInicio") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) java.util.Date dataInicio,
-    //         @RequestParam("dataFim") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) java.util.Date dataFim) {
-
-    //     logger.info("Data Início: " + dataInicio);
-    //     logger.info("Data Fim: " + dataFim);
-
-    //     return noticiaService.listarNoticiasPorData(dataInicio, dataFim);
-    // }
 }
-
-

--- a/src/main/java/edu/fatec/Porygon/model/Jornalista.java
+++ b/src/main/java/edu/fatec/Porygon/model/Jornalista.java
@@ -1,0 +1,49 @@
+package edu.fatec.Porygon.model;
+
+import jakarta.persistence.*;
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+// import com.fasterxml.jackson.annotation.JsonManagedReference;
+
+@Entity
+public class Jornalista {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String nome;
+
+    @OneToMany(mappedBy = "jornalista")
+    @JsonIgnore
+    private List<Noticia> noticias;
+
+    // @OneToMany(mappedBy = "jornalista", cascade = CascadeType.ALL)
+    // @JsonManagedReference // Controla a serialização da lista de notícias
+    // private List<Noticia> noticias;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getNome() {
+        return nome;
+    }
+
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+
+    public List<Noticia> getNoticias() {
+        return noticias;
+    }
+
+    public void setNoticias(List<Noticia> noticias) {
+        this.noticias = noticias;
+    }
+}
+

--- a/src/main/java/edu/fatec/Porygon/model/Jornalista.java
+++ b/src/main/java/edu/fatec/Porygon/model/Jornalista.java
@@ -2,31 +2,24 @@ package edu.fatec.Porygon.model;
 
 import jakarta.persistence.*;
 import java.util.List;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-// import com.fasterxml.jackson.annotation.JsonManagedReference;
 
 @Entity
 public class Jornalista {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
-
+    private Long id;
     private String nome;
 
     @OneToMany(mappedBy = "jornalista")
-    @JsonIgnore
     private List<Noticia> noticias;
 
-    // @OneToMany(mappedBy = "jornalista", cascade = CascadeType.ALL)
-    // @JsonManagedReference // Controla a serialização da lista de notícias
-    // private List<Noticia> noticias;
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 
@@ -46,4 +39,3 @@ public class Jornalista {
         this.noticias = noticias;
     }
 }
-

--- a/src/main/java/edu/fatec/Porygon/model/Noticia.java
+++ b/src/main/java/edu/fatec/Porygon/model/Noticia.java
@@ -2,7 +2,6 @@ package edu.fatec.Porygon.model;
 
 import jakarta.persistence.*;
 import java.util.Date;
-
 import com.fasterxml.jackson.annotation.JsonBackReference;
 
 @Entity
@@ -16,8 +15,10 @@ public class Noticia {
     @Temporal(TemporalType.DATE)
     @Column()
     private Date data;
+
     @Column(length = 20000)
     private String conteudo;
+
     private String autor;
 
     @Column(unique = true)
@@ -27,6 +28,11 @@ public class Noticia {
     @JoinColumn(name = "portal_id")
     @JsonBackReference
     private Portal portal;
+
+    @ManyToOne
+    @JoinColumn(name = "jornalista_id") 
+    @JsonBackReference
+    private Jornalista jornalista;;    
 
     public Integer getId() {
         return id;
@@ -76,7 +82,19 @@ public class Noticia {
         this.portal = portal;
     }
 
-    public String getHref() { return href; }
+    public String getHref() {
+        return href;
+    }
 
-    public void setHref(String href) { this.href = href; }
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    public Jornalista getJornalista() {
+        return jornalista;
+    }
+
+    public void setJornalista(Jornalista jornalista) {
+        this.jornalista = jornalista;
+    }
 }

--- a/src/main/java/edu/fatec/Porygon/model/Noticia.java
+++ b/src/main/java/edu/fatec/Porygon/model/Noticia.java
@@ -19,7 +19,6 @@ public class Noticia {
     @Column(length = 20000)
     private String conteudo;
 
-    private String autor;
 
     @Column(unique = true)
     private String href;
@@ -29,7 +28,7 @@ public class Noticia {
     @JsonBackReference
     private Portal portal;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "jornalista_id") 
     @JsonBackReference
     private Jornalista jornalista;;    
@@ -66,13 +65,6 @@ public class Noticia {
         this.conteudo = conteudo;
     }
 
-    public String getAutor() {
-        return autor;
-    }
-
-    public void setAutor(String autor) {
-        this.autor = autor;
-    }
 
     public Portal getPortal() {
         return portal;

--- a/src/main/java/edu/fatec/Porygon/repository/JornalistaRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/JornalistaRepository.java
@@ -1,0 +1,9 @@
+package edu.fatec.Porygon.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import edu.fatec.Porygon.model.Jornalista;
+
+public interface JornalistaRepository extends JpaRepository<Jornalista, Integer> {
+    Optional<Jornalista> findByNome(String nomeAutor);
+}

--- a/src/main/java/edu/fatec/Porygon/repository/JornalistaRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/JornalistaRepository.java
@@ -1,9 +1,9 @@
 package edu.fatec.Porygon.repository;
 
-import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
 import edu.fatec.Porygon.model.Jornalista;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
-public interface JornalistaRepository extends JpaRepository<Jornalista, Integer> {
-    Optional<Jornalista> findByNome(String nomeAutor);
+public interface JornalistaRepository extends JpaRepository<Jornalista, Long> {
+    Optional<Jornalista> findByNome(String nome);
 }

--- a/src/main/java/edu/fatec/Porygon/service/DataScrapperService.java
+++ b/src/main/java/edu/fatec/Porygon/service/DataScrapperService.java
@@ -29,6 +29,9 @@ public class DataScrapperService {
     @Autowired
     private PortalRepository portalRepository;
 
+    @Autowired
+    private JornalistaService jornalistaService;
+
     public void scrapeDatabyPortalID(int id) {
         Portal portal = portalRepository.findById(id).orElseThrow(() -> new RuntimeException("Portal not found with id: " + id));
 
@@ -81,7 +84,8 @@ public class DataScrapperService {
                 noticia.setHref(link);
 
                 if (!noticiaRepository.existsByHref(noticia.getHref())) {
-                    noticias.add(noticia); 
+                    jornalistaService.salvarOuAtualizarJornalista(noticia);
+                    noticias.add(noticia);
                 } else {
                     System.out.println("Notícia já existente: " + noticia.getHref());
                 }

--- a/src/main/java/edu/fatec/Porygon/service/JornalistaService.java
+++ b/src/main/java/edu/fatec/Porygon/service/JornalistaService.java
@@ -1,13 +1,11 @@
 package edu.fatec.Porygon.service;
 
-import java.util.Optional;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import edu.fatec.Porygon.model.Jornalista;
-import edu.fatec.Porygon.model.Noticia;
 import edu.fatec.Porygon.repository.JornalistaRepository;
-import edu.fatec.Porygon.repository.NoticiaRepository;
+import java.util.Optional;
 
 @Service
 public class JornalistaService {
@@ -15,27 +13,20 @@ public class JornalistaService {
     @Autowired
     private JornalistaRepository jornalistaRepository;
 
-    @Autowired
-    private NoticiaRepository noticiaRepository;
-
-    public void salvarOuAtualizarJornalista(Noticia noticia) {
-        String nomeAutor = noticia.getAutor();
+    @Transactional
+    public Jornalista salvarOuAtualizarJornalista(String nomeAutor) {
         if (nomeAutor.toLowerCase().startsWith("por ")) {
-            nomeAutor = nomeAutor.substring(4).trim(); // Remove "Por" e os espaços em branco
+            nomeAutor = nomeAutor.substring(4).trim();
         }
 
         Optional<Jornalista> jornalistaExistente = jornalistaRepository.findByNome(nomeAutor);
 
-        Jornalista jornalista;
         if (jornalistaExistente.isPresent()) {
-            jornalista = jornalistaExistente.get();
-        } else {
-            jornalista = new Jornalista();
-            jornalista.setNome(nomeAutor);
-            jornalista = jornalistaRepository.save(jornalista); // Salva o jornalista antes de associá-lo
+            return jornalistaExistente.get();
         }
 
-        noticia.setJornalista(jornalista);
-        noticiaRepository.save(noticia);
+        Jornalista novoJornalista = new Jornalista();
+        novoJornalista.setNome(nomeAutor);
+        return jornalistaRepository.save(novoJornalista);
     }
 }

--- a/src/main/java/edu/fatec/Porygon/service/JornalistaService.java
+++ b/src/main/java/edu/fatec/Porygon/service/JornalistaService.java
@@ -1,0 +1,41 @@
+package edu.fatec.Porygon.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import edu.fatec.Porygon.model.Jornalista;
+import edu.fatec.Porygon.model.Noticia;
+import edu.fatec.Porygon.repository.JornalistaRepository;
+import edu.fatec.Porygon.repository.NoticiaRepository;
+
+@Service
+public class JornalistaService {
+
+    @Autowired
+    private JornalistaRepository jornalistaRepository;
+
+    @Autowired
+    private NoticiaRepository noticiaRepository;
+
+    public void salvarOuAtualizarJornalista(Noticia noticia) {
+        String nomeAutor = noticia.getAutor();
+        if (nomeAutor.toLowerCase().startsWith("por ")) {
+            nomeAutor = nomeAutor.substring(4).trim(); // Remove "Por" e os espaços em branco
+        }
+
+        Optional<Jornalista> jornalistaExistente = jornalistaRepository.findByNome(nomeAutor);
+
+        Jornalista jornalista;
+        if (jornalistaExistente.isPresent()) {
+            jornalista = jornalistaExistente.get();
+        } else {
+            jornalista = new Jornalista();
+            jornalista.setNome(nomeAutor);
+            jornalista = jornalistaRepository.save(jornalista); // Salva o jornalista antes de associá-lo
+        }
+
+        noticia.setJornalista(jornalista);
+        noticiaRepository.save(noticia);
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://bootswatch.com/5/cerulean/bootstrap.min.css" rel="stylesheet">
     <style>
-        body{
+        body {
             font-size: 14px;
         }
     </style>
@@ -28,7 +28,8 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="nav justify-content-center">
                 <li class="nav-item">
-                    <a class="nav-link text-light" th:href="@{/index}">Consulta de Notícias<span class="sr-only">(atual)</span></a>
+                    <a class="nav-link text-light" th:href="@{/index}">Consulta de Notícias<span
+                            class="sr-only">(atual)</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das Api's</a>
@@ -110,8 +111,7 @@
                 </td>    -->
                             <td th:text="${#dates.format(noticia.data, 'dd/MM/yyyy')}"></td>
                             <td>
-                                <button class="btn btn-info"
-                                    th:onclick="'abrirModal(' + ${noticia.id} + ')'">Abrir</button>
+                                <button class="btn btn-info" th:onclick="|abrirModal(${noticia.id})|">Abrir</button>
                             </td>
                         </tr>
                     </tbody>
@@ -143,17 +143,17 @@
 
     <footer class="bg-dark text-light py-4">
         <div class="container text-center">
-          <p class="mb-0">© 2024 Porygon. Todos os direitos reservados.</p>
+            <p class="mb-0">© 2024 Porygon. Todos os direitos reservados.</p>
         </div>
-    </footer> 
-    
+    </footer>
+
     <script>
         function abrirModal(id) {
             fetch(`/noticias/detalhe/${id}`)
                 .then(response => response.json())
                 .then(data => {
                     document.getElementById('modalTitulo').innerText = data.titulo;
-                    document.getElementById('modalAutor').innerText = 'Jornalista: ' + data.autor;
+                    document.getElementById('modalAutor').innerText = 'Jornalista: ' + (data.jornalista ? data.jornalista.nome : 'Autor Desconhecido');
                     document.getElementById('modalData').innerText = 'Data de publicação: ' + new Date(data.data).toLocaleDateString('pt-BR');
                     document.getElementById('modalConteudo').innerText = data.conteudo;
                     var myModal = new bootstrap.Modal(document.getElementById('noticiaModal'));
@@ -161,30 +161,7 @@
                 })
                 .catch(error => console.error('Erro ao carregar os detalhes da notícia:', error));
         }
-        document.getElementById('consultar').addEventListener('click', function () {
-            const dataInicio = document.getElementById('dataInicio').value;
-            const dataFim = document.getElementById('dataFim').value;
 
-            fetch(`/noticias?dataInicio=${dataInicio}&dataFim=${dataFim}`)
-                .then(response => response.json())
-                .then(data => {
-                    // Atualize a tabela de notícias com os dados filtrados
-                    const tbody = document.querySelector('tbody.table-group-divider');
-                    tbody.innerHTML = '';
-                    data.forEach(noticia => {
-                        const row = document.createElement('tr');
-                        row.innerHTML = `
-                            <td>Inativo</td>
-                            <td>${noticia.titulo}</td>
-                            <td>Inativo</td>
-                            <td>${new Date(noticia.data).toLocaleDateString('pt-BR')}</td>
-                            <td><button class="btn btn-info" onclick="abrirModal(${noticia.id})">Abrir</button></td>
-                            `;
-                        tbody.appendChild(row);
-                    });
-                })
-                .catch(error => console.error('Erro ao carregar as notícias:', error));
-        });
     </script>
 
     <!-- Bootstrap JS e dependências -->


### PR DESCRIPTION
MELHORIA E IMPLEMENTAÇÃO
A principio configurei uma nova tabela chamada Jornalista que tem um serviço para abastecer conforme cadastramos os portais e realizamos a raspagem de noticias.
O seviço olha a tabela Noticia e a coluna autor , depois faz um simples tratamento e salva na coluna nome na tabela Jornalista , populando o banco automaticamente.
também foi colocado jornalista _id para saber a qual noticia aquele jornalista pertence.

Com tratamento de duplicação

NOVO COMMIT
@RuthMira
feat: coluna autor foi excluida de notica , agora a coluna nome em jornalista carrega a informação - ERRO EM EXIBIR NO MODAL O AUTOR
Agora não temos o nome do autor em dois locias somente em uma tabela , porém não consegui trazer na exibição do modal o nome do Jornalista da Noticia, po´rem as demais funcionalidades e a população dos nomes ao fazer a raspagem estão funcionando.