### PR TITLE
PYG-17 PYG-45 feat/style (noticia.controller, noticia.service e index): implementar paginacao no front-end e back-end

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
@@ -18,6 +18,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 
 @Controller
@@ -29,19 +32,45 @@ public class NoticiaController {
     private NoticiaService noticiaService;
 
     // private static final Logger logger = (Logger) LoggerFactory.getLogger(NoticiaController.class);
+    @GetMapping("/")
+    public String redirecionarParaIndex() {
+    return "redirect:/index";
+    }
 
     @GetMapping("/index")
-    public String listarNoticias(Model model) {
-        List<Noticia> noticias = noticiaRepository.findAll();
-        model.addAttribute("noticias", noticias);
-        return "index";
+    public String listarNoticias(@RequestParam(defaultValue = "0") int page, Model model) {
+    int pageSize = 5; // Tamanho da página
+    Page<Noticia> noticiasPage = noticiaRepository.findAll(PageRequest.of(page, pageSize));
+
+    model.addAttribute("noticias", noticiasPage.getContent());
+    model.addAttribute("paginaAtual", page + 1); // Para mostrar a página de forma amigável (1-indexed)
+    model.addAttribute("paginaAnterior", page - 1); // Para mostrar a página de forma amigável (1-indexed)
+    model.addAttribute("totalPaginas", noticiasPage.getTotalPages());
+
+    return "index";
     }
+
+    // Método para buscar o detalhe de uma notícia por ID
     @GetMapping("/noticias/detalhe/{id}")
     @ResponseBody
     public ResponseEntity<Noticia> detalheNoticiaJson(@PathVariable Integer id) {
-        Optional<Noticia> noticiaOptional = noticiaRepository.findById(id);
-        return noticiaOptional.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+        Optional<Noticia> noticiaOptional = noticiaService.findById(id);
+        return noticiaOptional.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
+
+    // @GetMapping("/index")
+    // public String listarNoticias(Model model) {
+    //     List<Noticia> noticias = noticiaRepository.findAll();
+    //     model.addAttribute("noticias", noticias);
+    //     return "index";
+    // }
+    // @GetMapping("/noticias/detalhe/{id}")
+    // @ResponseBody
+    // public ResponseEntity<Noticia> detalheNoticiaJson(@PathVariable Integer id) {
+    //     Optional<Noticia> noticiaOptional = noticiaRepository.findById(id);
+    //     return noticiaOptional.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+    // }
 
      @GetMapping("/noticias")
      @ResponseBody

--- a/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
@@ -2,9 +2,8 @@ package edu.fatec.Porygon.controller;
 
 import edu.fatec.Porygon.model.Noticia;
 import edu.fatec.Porygon.repository.NoticiaRepository;
-// import edu.fatec.Porygon.service.NoticiaService;
+import edu.fatec.Porygon.service.NoticiaService;
 
-import java.util.List;
 import java.util.Optional;
 
 // import org.slf4j.LoggerFactory;
@@ -14,10 +13,13 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-// import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 // import ch.qos.logback.classic.Logger;
 
@@ -26,12 +28,19 @@ public class NoticiaController {
 
     @Autowired
     private NoticiaRepository noticiaRepository;
+    private NoticiaService noticiaService;
+
+    @GetMapping("/")
+    public String redirecionarParaIndex() {
+    return "redirect:/index";
+}
+
     // @Autowired
     // private NoticiaService noticiaService;
 
     // private static final Logger logger = (Logger) LoggerFactory.getLogger(NoticiaController.class);
 
-    @GetMapping("/index")
+    /*@GetMapping("/index")
     public String listarNoticias(Model model) {
         List<Noticia> noticias = noticiaRepository.findAll();
         model.addAttribute("noticias", noticias);
@@ -42,7 +51,7 @@ public class NoticiaController {
     public ResponseEntity<Noticia> detalheNoticiaJson(@PathVariable Integer id) {
         Optional<Noticia> noticiaOptional = noticiaRepository.findById(id);
         return noticiaOptional.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
-    }
+    }/* */
 
     // @GetMapping("/noticias")
     // @ResponseBody
@@ -55,6 +64,24 @@ public class NoticiaController {
 
     //     return noticiaService.listarNoticiasPorData(dataInicio, dataFim);
     // }
+    @GetMapping("/index")
+    public String listarNoticias(@RequestParam(defaultValue = "0") int page, Model model) {
+    int pageSize = 5; // Tamanho da página
+    Page<Noticia> noticiasPage = noticiaRepository.findAll(PageRequest.of(page, pageSize));
+    
+    model.addAttribute("noticias", noticiasPage.getContent());
+    model.addAttribute("paginaAtual", page + 1); // Para mostrar a página de forma amigável (1-indexed)
+    model.addAttribute("totalPaginas", noticiasPage.getTotalPages());
+    
+    return "index";
 }
+    // Método para buscar o detalhe de uma notícia por ID
+    @GetMapping("/noticias/detalhe/{id}")
+    @ResponseBody
+    public ResponseEntity<Noticia> detalheNoticiaJson(@PathVariable Integer id) {
+        Optional<Noticia> noticiaOptional = noticiaService.findById(id);
+        return noticiaOptional.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+    }
 
-
+}

--- a/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
+++ b/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
@@ -2,7 +2,11 @@ package edu.fatec.Porygon.service;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import edu.fatec.Porygon.model.Noticia;
 import edu.fatec.Porygon.repository.NoticiaRepository;
@@ -19,5 +23,13 @@ public class NoticiaService {
 
     public List<Noticia> listarNoticiasPorData(LocalDate dataInicio, LocalDate dataFim) {
          return noticiaRepository.searchNewsByData(dataInicio, dataFim);
+    }
+        
+    public Page<Noticia> listarNoticias(Pageable pageable) {
+        return noticiaRepository.findAll(pageable);
+    }
+
+    public Optional<Noticia> findById(Integer id) {
+        return noticiaRepository.findById(id); 
     }
 }

--- a/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
+++ b/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
@@ -1,10 +1,14 @@
 package edu.fatec.Porygon.service;
 
 import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import edu.fatec.Porygon.model.Noticia;
 import edu.fatec.Porygon.repository.NoticiaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import java.util.Optional;
 
 @Service
 public class NoticiaService {
@@ -12,9 +16,20 @@ public class NoticiaService {
     @Autowired
     private NoticiaRepository noticiaRepository;
 
+    // Método para listar notícias paginadas
+    public Page<Noticia> listarNoticias(Pageable pageable) {
+        return noticiaRepository.findAll(pageable);
+    }
+
+    public Optional<Noticia> findById(Integer id) {
+        return noticiaRepository.findById(id);  // Reutilizando o método do NoticiaRepository
+    }
+
+    /*private NoticiaRepository noticiaRepository;
+
     public List<Noticia> listarNoticias() {
         return noticiaRepository.findAll();
-    }
+    }/* */
     
     // public List<Noticia> listarNoticiasPorData(java.util.Date dataInicio, java.util.Date dataFim) {
     //     return noticiaRepository.acharDataEntre(dataInicio, dataFim);

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -116,9 +116,24 @@
                         </tr>
                     </tbody>
                 </table>
+
+                <!-- Paginação -->
+                <nav aria-label="Navegação de página">
+                    <ul class="pagination justify-content-center">
+                        <li class="page-item" th:classappend="${paginaAtual == 1} ? 'disabled'">
+                            <a class="page-link" th:href="@{/index(page=${paginaAtual - 1})}">Anterior</a>
+                        </li>
+                        <li class="page-item" th:each="i : ${#numbers.sequence(1, totalPaginas)}"
+                            th:classappend="${i == paginaAtual} ? 'active'">
+                            <a class="page-link" th:href="@{/index(page=${i - 1})}" th:text="${i}"></a>
+                        </li>
+                        <li class="page-item" th:classappend="${paginaAtual == totalPaginas} ? 'disabled'">
+                            <a class="page-link" th:href="@{/index(page=${paginaAtual})}">Próximo</a>
+                        </li>
+                    </ul>
+                </nav>
             </div>
         </div>
-
     </div>
     <!-- Modal -->
     <div class="modal fade" id="noticiaModal" tabindex="-1" aria-labelledby="noticiaModalLabel" aria-hidden="true">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -124,7 +124,7 @@
                 <nav aria-label="Navegação de página">
                     <ul class="pagination justify-content-center">
                         <li class="page-item" th:classappend="${paginaAtual == 1} ? 'disabled'">
-                            <a class="page-link" th:href="@{/index(page=${paginaAtual - 1})}">Anterior</a>
+                            <a class="page-link" th:href="@{/index(page=${paginaAnterior})}">Anterior</a>
                         </li>
                         <li class="page-item" th:each="i : ${#numbers.sequence(1, totalPaginas)}"
                             th:classappend="${i == paginaAtual} ? 'active'">


### PR DESCRIPTION
Mudanças realizadas:

_### **NoticiaController:**_
Adicionado um novo mapeamento GET para a raiz (/), que redireciona para o endpoint /index.
O método listarNoticias precisou ser ajustado para adição de paginação;
Bibliotecas como Page, PageRequest, Pageable, RequestParam foram implementadas.
O método antigo se encontra no código, porém _comentado._

_**### NoticiaService:**_

Criado método para listar noticias paginadas;
O método antigo se encontra no código, porém _comentado._

_**### index.html:**_
Modificações foram feitas para garantir que a página não gere erros quando as variáveis esperadas não estão disponíveis.

Testes Realizados

Testei a aplicação acessando tanto http://localhost:8080/ quanto http://localhost:8080/index, e todas as páginas, ambos os caminhos funcionam corretamente, exibindo a página de notícias.

![image](https://github.com/user-attachments/assets/3ac37bd0-e423-4297-82c3-bf40785eee3b)

A lógica de paginação foi verificada e está funcionando como esperado, com as links para páginas anterior e próxima funcionando corretamente.
