### PR TITLE
PYG-17 PYG-44 fix(front): exibir noticias filtradas em ordem

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
@@ -5,6 +5,7 @@ import edu.fatec.Porygon.repository.NoticiaRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Comparator;
 import edu.fatec.Porygon.service.NoticiaService;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,7 @@ public class NoticiaController {
     @GetMapping("/")
     public String listarNoticias(Model model) {
         List<Noticia> noticias = noticiaRepository.findAll();
+        noticias.sort(Comparator.comparing(Noticia::getTitulo));
         model.addAttribute("noticias", noticias);
         return "index";
     }
@@ -54,6 +56,7 @@ public class NoticiaController {
         }
 
         List<Noticia> noticias = noticiaService.listarNoticiasPorData(dataInicio, dataFim);
+        noticias.sort(Comparator.comparing(Noticia::getData));
         return ResponseEntity.ok(noticias);
     }
 }

--- a/src/main/java/edu/fatec/Porygon/controller/PortalController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/PortalController.java
@@ -107,9 +107,9 @@ public class PortalController {
     
         if (!isEdit && portal.isAtivo()) {
             dataScrapperService.WebScrapper();
-            successMessage = "Cadastro de portal e primeira coleta de notícias realizada com sucesso!";
+            successMessage = "Cadastro de portal e primeira coleta realizada com sucesso!";
         } else if (!portal.isAtivo()) {
-            successMessage = "Cadastro de portal realizado, mas a coleta não foi feita pois o portal está desativado.";
+            successMessage = "Cadastro de portal realizado sem coleta por estar desativo.";
         } else {
             successMessage = "Portal editado com sucesso!";
         }

--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -65,7 +65,7 @@
                     <a class="nav-link text-light" th:href="@{/}">Consulta de Notícias</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das Api's</a>
+                    <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das APIs</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link text-light" th:href="@{/portais}">Cadastro de Portal</a>

--- a/src/main/resources/templates/apiDados.html
+++ b/src/main/resources/templates/apiDados.html
@@ -31,7 +31,7 @@
                 <a class="nav-link text-light" th:href="@{/}">Consulta de Notícias</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das Api's<span
+                <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das APIs<span
                         class="sr-only">(atual)</span></a>
             </li>
             <li class="nav-item">
@@ -47,7 +47,7 @@
 <br>
 
 <div class="container mt-5">
-    <h4 class="mb-4 text-center">Consulta de API`s</h4>
+    <h4 class="mb-4 text-center">Consulta de APIs</h4>
 
     <!-- Formulário de Filtros (Desativado) -->
     <form>
@@ -87,7 +87,7 @@
 
     <!-- Lista de Dados das Api's -->
     <div class="mt-5">
-        <h4 class="mb-4 text-center">Lista de Dados das Api's</h4>
+        <h4 class="mb-4 text-center">Lista de Dados das APIs</h4>
         <div class="table-responsive">
             <table class="table table-striped table-hover">
                 <thead>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -34,7 +34,7 @@
                     <a class="nav-link text-light" th:href="@{/}">Consulta de Notícias<span class="sr-only">(atual)</span></a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das Api's</a>
+                    <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das APIs</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link text-light" th:href="@{/portais}">Cadastro de Portal</a>
@@ -49,7 +49,7 @@
     <br>
 
     <div class="container mt-5">
-        <h4 class="mb-4 text-center">Portal de Consultas</h4>
+        <h4 class="mb-4 text-center">Consulta de Notícias</h4>
 
         <!-- Formulário de Filtros (Desativado) -->
         <form id="filterForm">

--- a/src/main/resources/templates/portal.html
+++ b/src/main/resources/templates/portal.html
@@ -76,7 +76,7 @@
                     <a class="nav-link text-light" th:href="@{/}">Consulta de Notícias</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das Api's</a>
+                    <a class="nav-link text-light" th:href="@{/apis/dados}">Consulta de Dados das APIs</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link text-light" th:href="@{/portais}">Cadastro de Portal<span class="sr-only">(atual)</span></a>


### PR DESCRIPTION
Atualizei as listas dos métodos listarNoticias e listarNoticiasPorData com .sort e Comparator.comparing para ordenar de acordo com o tipo de variável. Na listagem original, sem filtros, está em ordem alfabética. Na listagem quando filtra por uma data, está por ordem crescente numérica. 
Fiz algumas alterações que estavam como melhorias, vou retirar essa task do Jira. Alterei em todos os html o Api's para APIs em tudo, para padronizar. Também como padronização, mudei de "Portal de Consultas" para "Consulta de Notícias"
Editei os avisos na tela para o cliente, pois alguns caracteres estavam quebrando. Deixei frases que não contenham ~, ´, ç, etc. 
**PEÇO QUE RODEM O PROGRAMA COMPLETO, TESTANDO TODAS AS FUNCIONALIDADES DISPONÍVEIS**