### PR TITLE
PYG-14 PYG-69 feat(TagService): cria método para salvar a tag no banco de acordo com as validações

### DIFF
--- a/src/main/java/edu/fatec/Porygon/model/Sinonimo.java
+++ b/src/main/java/edu/fatec/Porygon/model/Sinonimo.java
@@ -9,7 +9,7 @@ public class Sinonimo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
-    @Column(unique = true) 
+    @Column(unique = true, length = 46)
     private String nome;
 
     @ManyToOne

--- a/src/main/java/edu/fatec/Porygon/model/Tag.java
+++ b/src/main/java/edu/fatec/Porygon/model/Tag.java
@@ -1,7 +1,16 @@
 package edu.fatec.Porygon.model;
 
 import java.util.List;
-import jakarta.persistence.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 
 @Entity
 public class Tag {
@@ -9,7 +18,7 @@ public class Tag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
     
-    @Column(unique = true) 
+    @Column(unique = true, length = 46)
     private String nome;
 
     @OneToMany(mappedBy = "tag", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/edu/fatec/Porygon/service/TagService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagService.java
@@ -20,7 +20,7 @@ public class TagService {
 
     public Tag criarTag(Tag tag) {
         if (tagRepository.existsByNome(tag.getNome())) {
-            throw new RuntimeException("A tag com esse nome já existe.");
+            throw new IllegalArgumentException("A tag já existe.");
         }
     
         Tag novaTag = tagRepository.save(tag);

--- a/src/test/java/edu/fatec/Porygon/PorygonApplicationTests.java
+++ b/src/test/java/edu/fatec/Porygon/PorygonApplicationTests.java
@@ -32,12 +32,21 @@ class PorygonApplicationTests {
 
         assertNotNull(sinonimos, "A lista de sinônimos não foi preenchida.");
         assertFalse(sinonimos.isEmpty(), "Nenhum sinônimo foi salvo.");
+    }
 
-        List<String> nomesSinonimos = sinonimos.stream()
-                                               .map(Sinonimo::getNome)
-                                               .collect(Collectors.toList());
+    @Test
+    void testValidarNomeTag() {
+        Tag tagValida = new Tag();
+        tagValida.setNome("palavra-composta");
+        assertTrue(tagValida.getNome().length() < 46, "A tag deve ter menos de 46 caracteres.");
+        assertTrue(tagValida.getNome().contains("-"), "A tag deve ser composta e conter hífen.");
 
-        assertTrue(nomesSinonimos.contains("mandioca"), "Sinônimo esperado 'mandioca' não encontrado.");
-        assertTrue(nomesSinonimos.contains("aipim"), "Sinônimo esperado 'aipim' não encontrado.");
+        Tag tagInvalidaSemHifen = new Tag();
+        tagInvalidaSemHifen.setNome("palavracomposta");
+        assertFalse(tagInvalidaSemHifen.getNome().contains("-"), "A tag não deve ser composta.");
+
+        Tag tagInvalidaComprida = new Tag();
+        tagInvalidaComprida.setNome("essa-tag-excede-o-limite-de-quarenta-e-seis-caracteres-e-deve-falhar");
+        assertFalse(tagInvalidaComprida.getNome().length() < 46, "A tag deve ter menos de 46 caracteres.");
     }
 }


### PR DESCRIPTION
## Validação do Método que Salva as Tags
Validei o método que salva as tags. Apesar de no JIRA pedir para salvar tudo com hífen, lembro que em reunião discutimos sobre os casos de palavras compostas que realmente têm o hífen, então iríamos armazenar da maneira que elas são escritas aqui nesta tarefa.

#### Banco Tag
![image](https://github.com/user-attachments/assets/35845611-2fd9-41ca-b82e-0c7f30dbd7c0)

#### Banco Sinonimo
![image](https://github.com/user-attachments/assets/aa53bab3-0ae9-4163-b3ba-16b62a7eac14)


### Teste Unitário
Pode utilizar o mesmo arquivo de teste `PorygonApplicationTests.java`.
