### PR TITLE
PYG-14/PYG-68/Feat/Verificacao-Regionalismo

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/TagController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/TagController.java
@@ -18,7 +18,7 @@ public class TagController {
     @GetMapping
     public String mostrarFormularioCadastro(Model model) {
         model.addAttribute("tag", new Tag());
-        model.addAttribute("tags", tagService.listarTagsOrdenadas());
+        model.addAttribute("tags", tagService.listarTagsOrdenadas()); // Certifique-se de que este método está disponível
         return "tag";
     }
 

--- a/src/main/java/edu/fatec/Porygon/controller/TagController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/TagController.java
@@ -5,9 +5,7 @@ import edu.fatec.Porygon.service.TagService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -29,6 +27,17 @@ public class TagController {
         try {
             tagService.criarTag(tag);
             redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag cadastrada com sucesso!");
+        } catch (RuntimeException e) {
+            redirectAttributes.addFlashAttribute("mensagemErro", e.getMessage());
+        }
+        return "redirect:/tags";
+    }
+
+    @PostMapping("/editar/{id}")
+    public String editarTag(@PathVariable Integer id, @RequestParam String novoNome, RedirectAttributes redirectAttributes) {
+        try {
+            tagService.editarTag(id, novoNome);
+            redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag atualizada com sucesso!");
         } catch (RuntimeException e) {
             redirectAttributes.addFlashAttribute("mensagemErro", e.getMessage());
         }

--- a/src/main/java/edu/fatec/Porygon/controller/TagController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/TagController.java
@@ -18,7 +18,7 @@ public class TagController {
     @GetMapping
     public String mostrarFormularioCadastro(Model model) {
         model.addAttribute("tag", new Tag());
-        model.addAttribute("tags", tagService.listarTagsOrdenadas()); // Certifique-se de que este método está disponível
+        model.addAttribute("tags", tagService.listarTagsOrdenadas());
         return "tag";
     }
 
@@ -29,7 +29,7 @@ public class TagController {
                 tagService.editarTag(tag.getId(), tag.getNome());
                 redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag atualizada com sucesso!");
             } else {
-                tagService.criarTag(tag); // Isso agora verifica duplicidade
+                tagService.criarTag(tag);
                 redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag cadastrada com sucesso!");
             }
         } catch (RuntimeException e) {
@@ -40,9 +40,9 @@ public class TagController {
 
     @GetMapping("/editar/{id}")
     public String mostrarFormularioEdicao(@PathVariable Integer id, Model model) {
-        Tag tag = tagService.buscarTagPorId(id); // Método para buscar a tag pelo ID
+        Tag tag = tagService.buscarTagPorId(id);
         model.addAttribute("tag", tag);
         model.addAttribute("tags", tagService.listarTagsOrdenadas());
-        return "tag"; // Retorna para a mesma página, mas agora com a tag a ser editada
+        return "tag";
     }
 }

--- a/src/main/java/edu/fatec/Porygon/controller/TagController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/TagController.java
@@ -23,24 +23,26 @@ public class TagController {
     }
 
     @PostMapping("/salvar")
-    public String salvarTag(Tag tag, RedirectAttributes redirectAttributes) {
+    public String salvarTag(@ModelAttribute Tag tag, RedirectAttributes redirectAttributes) {
         try {
-            tagService.criarTag(tag);
-            redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag cadastrada com sucesso!");
+            if (tag.getId() != null) {
+                tagService.editarTag(tag.getId(), tag.getNome());
+                redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag atualizada com sucesso!");
+            } else {
+                tagService.criarTag(tag); // Isso agora verifica duplicidade
+                redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag cadastrada com sucesso!");
+            }
         } catch (RuntimeException e) {
             redirectAttributes.addFlashAttribute("mensagemErro", e.getMessage());
         }
         return "redirect:/tags";
     }
 
-    @PostMapping("/editar/{id}")
-    public String editarTag(@PathVariable Integer id, @RequestParam String novoNome, RedirectAttributes redirectAttributes) {
-        try {
-            tagService.editarTag(id, novoNome);
-            redirectAttributes.addFlashAttribute("mensagemSucesso", "Tag atualizada com sucesso!");
-        } catch (RuntimeException e) {
-            redirectAttributes.addFlashAttribute("mensagemErro", e.getMessage());
-        }
-        return "redirect:/tags";
+    @GetMapping("/editar/{id}")
+    public String mostrarFormularioEdicao(@PathVariable Integer id, Model model) {
+        Tag tag = tagService.buscarTagPorId(id); // Método para buscar a tag pelo ID
+        model.addAttribute("tag", tag);
+        model.addAttribute("tags", tagService.listarTagsOrdenadas());
+        return "tag"; // Retorna para a mesma página, mas agora com a tag a ser editada
     }
 }

--- a/src/main/java/edu/fatec/Porygon/model/Sinonimo.java
+++ b/src/main/java/edu/fatec/Porygon/model/Sinonimo.java
@@ -3,13 +3,14 @@ package edu.fatec.Porygon.model;
 import jakarta.persistence.*;
 
 @Entity
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"nome", "tag_id"})})
 public class Sinonimo {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
-    @Column(unique = true, length = 46)
+
+    @Column(length = 46)
     private String nome;
 
     @ManyToOne

--- a/src/main/java/edu/fatec/Porygon/repository/SinonimoRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/SinonimoRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SinonimoRepository extends JpaRepository<Sinonimo, Integer> {
-
     boolean existsByNomeAndTag(String nome, Tag tag);
     void deleteByTag(Tag tag);
     List<Sinonimo> findByTag(Tag tag);

--- a/src/main/java/edu/fatec/Porygon/repository/SinonimoRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/SinonimoRepository.java
@@ -5,7 +5,7 @@ import edu.fatec.Porygon.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
-public interface SinonimoRepository extends JpaRepository<Sinonimo, Long> {
+public interface SinonimoRepository extends JpaRepository<Sinonimo, Integer> {
 
     boolean existsByNomeAndTag(String nome, Tag tag);
     void deleteByTag(Tag tag);

--- a/src/main/java/edu/fatec/Porygon/repository/SinonimoRepository.java
+++ b/src/main/java/edu/fatec/Porygon/repository/SinonimoRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SinonimoRepository extends JpaRepository<Sinonimo, Long> {
-    
-    boolean existsByNome(String nome);
+
+    boolean existsByNomeAndTag(String nome, Tag tag);
     void deleteByTag(Tag tag);
     List<Sinonimo> findByTag(Tag tag);
 }

--- a/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
@@ -12,7 +12,7 @@ public class TagScrapperService {
     public static List<String> buscarSinonimos(String palavra) {
         List<String> sinonimos = buscarSinonimosDicio(palavra);
         if (sinonimos == null || sinonimos.isEmpty()) {
-            sinonimos = buscarSinonimosAlternativo(palavra);
+            sinonimos = buscarSinonimosSinonimos(palavra);
         }
         return sinonimos;
     }
@@ -39,7 +39,7 @@ public class TagScrapperService {
         return null;
     }
 
-    private static List<String> buscarSinonimosAlternativo(String palavra) {
+    private static List<String> buscarSinonimosSinonimos(String palavra) {
         try {
             String url = "https://www.sinonimos.com.br/" + palavra + "/";
             Document doc = Jsoup.connect(url).get();

--- a/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
@@ -3,21 +3,29 @@ package edu.fatec.Porygon.service;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+@Service
 public class TagScrapperService {
 
-    public static List<String> buscarSinonimos(String palavra) {
-        List<String> sinonimos = buscarSinonimosDicio(palavra);
-        if (sinonimos == null || sinonimos.isEmpty()) {
-            sinonimos = buscarSinonimosSinonimos(palavra);
-        }
-        return sinonimos;
+    public List<String> buscarSinonimos(String palavra) {
+        List<String> sinonimosDicio = buscarSinonimosDicio(palavra);
+        List<String> sinonimosSinonimos = buscarSinonimosSinonimos(palavra);
+
+        // Combina os sinônimos dos dois sites, removendo duplicatas
+        return Stream.concat(sinonimosDicio.stream(), sinonimosSinonimos.stream())
+                .distinct()
+                .collect(Collectors.toList());
     }
 
-    private static List<String> buscarSinonimosDicio(String palavra) {
+    private List<String> buscarSinonimosDicio(String palavra) {
         try {
             String url = "https://www.dicio.com.br/" + palavra + "/";
             Document doc = Jsoup.connect(url).get();
@@ -33,13 +41,13 @@ public class TagScrapperService {
                             .collect(Collectors.toList());
                 }
             }
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (IOException e) {
+            System.err.println("Erro ao buscar sinônimos no Dicio: " + e.getMessage());
         }
-        return null;
+        return Collections.emptyList();
     }
 
-    private static List<String> buscarSinonimosSinonimos(String palavra) {
+    private List<String> buscarSinonimosSinonimos(String palavra) {
         try {
             String url = "https://www.sinonimos.com.br/" + palavra + "/";
             Document doc = Jsoup.connect(url).get();
@@ -50,9 +58,9 @@ public class TagScrapperService {
                         .map(element -> element.text().trim())
                         .collect(Collectors.toList());
             }
-        } catch (Exception e) {
-            e.printStackTrace();
+        } catch (IOException e) {
+            System.err.println("Erro ao buscar sinônimos no Sinonimos.com.br: " + e.getMessage());
         }
-        return null;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
@@ -10,6 +10,14 @@ import java.util.stream.Collectors;
 public class TagScrapperService {
 
     public static List<String> buscarSinonimos(String palavra) {
+        List<String> sinonimos = buscarSinonimosDicio(palavra);
+        if (sinonimos == null || sinonimos.isEmpty()) {
+            sinonimos = buscarSinonimosAlternativo(palavra);
+        }
+        return sinonimos;
+    }
+
+    private static List<String> buscarSinonimosDicio(String palavra) {
         try {
             String url = "https://www.dicio.com.br/" + palavra + "/";
             Document doc = Jsoup.connect(url).get();
@@ -24,6 +32,23 @@ public class TagScrapperService {
                             .map(String::trim)
                             .collect(Collectors.toList());
                 }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private static List<String> buscarSinonimosAlternativo(String palavra) {
+        try {
+            String url = "https://www.sinonimos.com.br/" + palavra + "/";
+            Document doc = Jsoup.connect(url).get();
+            Elements sinonimos = doc.select("a.sinonimo");
+
+            if (!sinonimos.isEmpty()) {
+                return sinonimos.stream()
+                        .map(element -> element.text().trim())
+                        .collect(Collectors.toList());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagScrapperService.java
@@ -18,8 +18,6 @@ public class TagScrapperService {
     public List<String> buscarSinonimos(String palavra) {
         List<String> sinonimosDicio = buscarSinonimosDicio(palavra);
         List<String> sinonimosSinonimos = buscarSinonimosSinonimos(palavra);
-
-        // Combina os sinônimos dos dois sites, removendo duplicatas
         return Stream.concat(sinonimosDicio.stream(), sinonimosSinonimos.stream())
                 .distinct()
                 .collect(Collectors.toList());
@@ -59,7 +57,7 @@ public class TagScrapperService {
                         .collect(Collectors.toList());
             }
         } catch (IOException e) {
-            System.err.println("Erro ao buscar sinônimos no Sinonimos.com.br: " + e.getMessage());
+            System.err.println("Erro ao buscar sinônimos no Sinonimos" + e.getMessage());
         }
         return Collections.emptyList();
     }

--- a/src/main/java/edu/fatec/Porygon/service/TagService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagService.java
@@ -7,9 +7,9 @@ import edu.fatec.Porygon.model.Tag;
 import edu.fatec.Porygon.model.Sinonimo;
 import edu.fatec.Porygon.repository.TagRepository;
 import edu.fatec.Porygon.repository.SinonimoRepository;
+
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Optional;
 
 @Service
 public class TagService {
@@ -73,5 +73,10 @@ public class TagService {
 
     public List<Tag> listarTagsOrdenadas() {
         return tagRepository.findAll(Sort.by(Sort.Direction.ASC, "nome"));
+    }
+
+    public Tag buscarTagPorId(Integer id) {
+        return tagRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tag não encontrada."));
     }
 }

--- a/src/main/java/edu/fatec/Porygon/service/TagService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagService.java
@@ -9,6 +9,7 @@ import edu.fatec.Porygon.repository.TagRepository;
 import edu.fatec.Porygon.repository.SinonimoRepository;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Optional;
 
 @Service
 public class TagService {
@@ -23,28 +24,52 @@ public class TagService {
         if (tagRepository.existsByNome(tag.getNome())) {
             throw new IllegalArgumentException("A tag já existe.");
         }
-    
+
         Tag novaTag = tagRepository.save(tag);
-    
         List<String> sinonimos = TagScrapperService.buscarSinonimos(novaTag.getNome());
-    
+        vincularSinonimos(sinonimos, novaTag);
+
+        return novaTag;
+    }
+
+    public Tag editarTag(Integer id, String novoNome) {
+        Optional<Tag> optionalTag = tagRepository.findById(id);
+        if (optionalTag.isEmpty()) {
+            throw new IllegalArgumentException("Tag não encontrada.");
+        }
+
+        Tag tagExistente = optionalTag.get();
+        if (!tagExistente.getNome().equalsIgnoreCase(novoNome) && tagRepository.existsByNome(novoNome)) {
+            throw new IllegalArgumentException("Uma tag com este nome já existe.");
+        }
+
+        tagExistente.setNome(novoNome);
+        tagRepository.save(tagExistente);
+
+        List<String> sinonimos = TagScrapperService.buscarSinonimos(tagExistente.getNome());
+        vincularSinonimos(sinonimos, tagExistente);
+
+        return tagExistente;
+    }
+
+    private void vincularSinonimos(List<String> sinonimos, Tag tag) {
         if (sinonimos != null && !sinonimos.isEmpty()) {
             List<Sinonimo> sinonimoList = new ArrayList<>();
             for (String sinonimoNome : sinonimos) {
                 if (!sinonimoRepository.existsByNome(sinonimoNome)) {
                     Sinonimo sinonimo = new Sinonimo();
                     sinonimo.setNome(sinonimoNome);
-                    sinonimo.setTag(novaTag);
+                    sinonimo.setTag(tag);
                     sinonimoList.add(sinonimo);
                 }
             }
             sinonimoRepository.saveAll(sinonimoList);
-            novaTag.setSinonimos(sinonimoList);
+            tag.setSinonimos(sinonimoList);
         } else {
-            novaTag.setSinonimos(new ArrayList<>()); 
+            tag.setSinonimos(new ArrayList<>());
         }
-        return novaTag;
     }
+
     public List<Tag> listarTagsOrdenadas() {
         return tagRepository.findAll(Sort.by(Sort.Direction.ASC, "nome"));
     }

--- a/src/main/java/edu/fatec/Porygon/service/TagService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagService.java
@@ -48,13 +48,11 @@ public class TagService {
     }
 
     private void atualizarSinonimos(Tag tag) {
-        // Busca os sinônimos atualizados
         List<String> sinonimos = tagScrapperService.buscarSinonimos(tag.getNome());
         vincularSinonimos(sinonimos, tag);
     }
 
     private void vincularSinonimos(List<String> sinonimos, Tag tag) {
-        // Remove sinônimos antigos que não estão na nova lista
         List<Sinonimo> sinonimosAntigos = sinonimoRepository.findByTag(tag);
         for (Sinonimo sinonimoAntigo : sinonimosAntigos) {
             if (!sinonimos.contains(sinonimoAntigo.getNome())) {
@@ -62,7 +60,6 @@ public class TagService {
             }
         }
 
-        // Adiciona novos sinônimos
         for (String sinonimoNome : sinonimos) {
             if (!sinonimoRepository.existsByNomeAndTag(sinonimoNome, tag)) {
                 Sinonimo sinonimo = new Sinonimo();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=Porygon
 
 spring.datasource.url=jdbc:mysql://localhost:3306/porygon?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=porygon
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=Porygon
 
 spring.datasource.url=jdbc:mysql://localhost:3306/porygon?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=porygon
+spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/templates/tag.html
+++ b/src/main/resources/templates/tag.html
@@ -13,13 +13,17 @@
         body {
             font-size: 16px;
         }
+
         .form-label {
             font-size: 1.1rem;
         }
+
         .form-control {
             font-size: 1rem;
         }
-        html, body {
+
+        html,
+        body {
             height: 100%;
         }
 
@@ -83,10 +87,12 @@
 
     <h4 class="mb-4 text-center">Cadastro de Tag</h4>
     <form th:action="@{/tags/salvar}" method="post">
+        <input type="hidden" th:if="${tag.id}" th:name="id" th:value="${tag.id}"/>
         <div class="row mb-3">
             <div class="col-md-6 offset-md-3">
                 <label for="nome" class="form-label">Nome da Tag:</label>
-                <input type="text" class="form-control" id="nome" name="nome" placeholder="Digite o nome da Tag" required>
+                <input type="text" class="form-control" id="nome" name="nome"
+                       th:placeholder="${tag.nome}" th:value="${tag.nome}" required>
                 <small class="form-text text-muted">Cadastre uma Tag de cada vez e separe palavras compostas com hífen ( - ), sem espaços.</small>
             </div>
         </div>
@@ -111,7 +117,7 @@
                 <td th:text="${tag.id}"></td>
                 <td th:text="${tag.nome}"></td>
                 <td class="acoes-column">
-                    <a class="btn btn-info btn-sm">Editar</a>
+                    <a th:href="@{/tags/editar/{id}(id=${tag.id})}" class="btn btn-info btn-sm">Editar</a>
                 </td>
             </tr>
             </tbody>


### PR DESCRIPTION
Implementar uma função de busca para verificar as tags cadastradas e a existência de regionalismos e sinônimos, vinculando o id do sinônimo em uma coluna “sinônimo” na tabela tag. (back e banco)

Critérios de Aceite:

O sistema deve suportar tags com regionalismos, vinculando automaticamente palavras com significados iguais. :heavy_check_mark:
Uma tabela alimentada por APIs de sinônimos será utilizada no relacionamento entre tags e sinônimos. :heavy_check_mark:
O usuário deve ser capaz de editar uma tag cadastrada, com validação de consistência e duplicidade.  :heavy_check_mark:

