### PR TITLE
PYG-14 PYG-87 feat(TagService): criando padronização dastags no banco

### DIFF
--- a/src/main/java/edu/fatec/Porygon/service/TagService.java
+++ b/src/main/java/edu/fatec/Porygon/service/TagService.java
@@ -20,10 +20,15 @@ public class TagService {
     private SinonimoRepository sinonimoRepository;
 
     public Tag criarTag(Tag tag) {
-        if (tagRepository.existsByNome(tag.getNome())) {
+
+        String newTagName = StandardizeTag(tag);
+
+        if (tagRepository.existsByNome(newTagName)) {
             throw new IllegalArgumentException("A tag já existe.");
         }
-    
+
+        tag.setNome(newTagName);
+
         Tag novaTag = tagRepository.save(tag);
     
         List<String> sinonimos = TagScrapperService.buscarSinonimos(novaTag.getNome());
@@ -48,4 +53,25 @@ public class TagService {
     public List<Tag> listarTagsOrdenadas() {
         return tagRepository.findAll(Sort.by(Sort.Direction.ASC, "nome"));
     }
+
+    public String StandardizeTag(Tag tag) {
+        String modifiedTag = tag.getNome();
+        String returnTag = "";
+
+        if (modifiedTag == null || modifiedTag.isEmpty()) {
+            returnTag = modifiedTag;
+        }else{
+            String[] nameWords = modifiedTag.replaceAll("-"," ").toLowerCase().split("\\s+");
+            StringBuilder newString = new StringBuilder();
+            for (String word : nameWords) {
+                if (!word.isEmpty()) {
+                    newString.append(Character.toUpperCase(word.charAt(0))).append(word.substring(1)).append(" ");
+                }
+            }
+            returnTag = newString.toString().trim();
+        }
+
+        return returnTag;
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=Porygon
 
 spring.datasource.url=jdbc:mysql://localhost:3306/porygon?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
Criada a função para padronizar a nomenclatura das tags cadastradas antes de salva-las no banco, retirando o "-" entre as palavras e substituindo por espaço, tal como realizando a capitalização (deixar a primeira letra de cada palavra como maiúscula) das mesmas (ex.: Se o usuário cadastrar São-PAULO, o banco vai armazenar como “São Paulo”).

