### PR TITLE
PYG-14/PYG-88/fix/adiciona-busca-elastica-e-altera-coluna-api

### DIFF
--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -158,13 +158,11 @@
                         <td th:text="${api.nome}"></td>
                         <td th:text="${api.descricao}"></td>
                         <td th:text="${api.url}"></td>
-                        <td th:text="'Inativo'">Inativo</td>
                         <td>
                             <span th:if="${#lists.isEmpty(api.tags)}">Nenhuma Tag</span>
                             <span th:each="tag, iterStat : ${api.tags}">
                                 <span th:text="${tag.nome}"></span>
                                 <span th:if="${!iterStat.last}">, </span>
-
                             </span>
                         </td>
                         <td th:text="${api.agendador != null ? api.agendador.tipo : 'Sem Agendador'}"></td>

--- a/src/main/resources/templates/api.html
+++ b/src/main/resources/templates/api.html
@@ -109,25 +109,25 @@
                         <label class="form-check-label" for="ativo"><strong>Ativa</strong></label>
                     </div>
                 </div>
-
             </div>
 
             <div class="row mb-3">
                 <div class="col-md-6">
-                    <label for="tags" class="form-label">Tags</label>
-                    <select id="tags" name="tagIds" class="form-select" multiple required onchange="updateSelectedTags()">
-                        <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"
-                            th:selected="${api.tags != null && api.tags.contains(tag)}">
-                        </option>
-                    </select>
-                    <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas
-                        opções.</small>
+                    <div class="flex-grow-1"> 
+                        <label for="tagSearchInput" class="form-label">Buscar Tags</label>
+                        <input type="text" class="form-control" id="tagSearchInput" placeholder="Digite para buscar tags">
+                        <div id="selected-tags" class="d-flex flex-wrap mt-2"></div>
+                    </div>
                 </div>
                 <div class="col-md-6">
-                    <br>
-                    <div id="selected-tags" class="d-flex flex-wrap"></div>
+                    <label for="tags" class="form-label">Tags</label>
+                    <select id="tags" name="tagIds" class="form-select" multiple required onchange="updateSelectedTags()">
+                        <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}" th:selected="${api.tags != null && api.tags.contains(tag)}">
+                        </option>
+                    </select>
+                    <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas opções.</small>
                 </div>
-            </div>
+            </div>  
 
             <div class="d-grid gap-2 col-2 mx-auto">
                 <button type="submit" class="btn btn-primary">Salvar</button>
@@ -191,6 +191,25 @@
 
 
     <script>
+
+        const tagInput = document.getElementById('tagSearchInput');
+        const tagSelect = document.getElementById('tags');
+        const allTags = Array.from(tagSelect.options);
+
+        // Escuta o input do usuário e filtra as tags
+        tagInput.addEventListener('input', function() {
+            const searchQuery = this.value.toLowerCase();
+            tagSelect.innerHTML = ''; // Limpa as opções visíveis
+
+            // Filtra as opções que começam com o texto digitado
+            const filteredTags = allTags.filter(tag => tag.text.toLowerCase().startsWith(searchQuery));
+            
+            // Adiciona as opções filtradas de volta no select
+            filteredTags.forEach(tag => {
+                tagSelect.appendChild(tag);
+            });
+            updateSelectedTags();
+        });
         function updateSelectedTags() {
             const select = document.getElementById('tags');
             const selectedTagsContainer = document.getElementById('selected-tags');

--- a/src/main/resources/templates/portal.html
+++ b/src/main/resources/templates/portal.html
@@ -96,19 +96,21 @@
 
             <div class="row mb-3">
                 <div class="col-md-6">
+                    <div class="flex-grow-1"> 
+                        <label for="tagSearchInput" class="form-label">Buscar Tags</label>
+                        <input type="text" class="form-control" id="tagSearchInput" placeholder="Digite para buscar tags">
+                        <div id="selected-tags" class="d-flex flex-wrap mt-2"></div>
+                    </div>
+                </div>
+                <div class="col-md-6">
                     <label for="tags" class="form-label">Tags</label>
                     <select id="tags" name="tagIds" class="form-select" multiple required onchange="updateSelectedTags()">
-                        <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}"
-                            th:selected="${portal.tags != null && portal.tags.contains(tag)}">
+                        <option th:each="tag : ${tags}" th:value="${tag.id}" th:text="${tag.nome}" th:selected="${portal.tags != null && portal.tags.contains(tag)}">
                         </option>
                     </select>
                     <small class="form-text text-muted">Segure a tecla Ctrl (ou Command) para selecionar múltiplas opções.</small>
                 </div>
-                <div class="col-md-6">
-                    <br>
-                    <div id="selected-tags" class="d-flex flex-wrap"></div>
-                </div>
-            </div>                        
+            </div>                      
 
             <h4 class="mb-3 text-center">Cadastro de Seletores</h4>
             <div class="row mb-3">
@@ -202,12 +204,31 @@
     </footer>
 
     <script>
+
+        const tagInput = document.getElementById('tagSearchInput');
+        const tagSelect = document.getElementById('tags');
+        const allTags = Array.from(tagSelect.options);
+
+        // Escuta o input do usuário e filtra as tags
+        tagInput.addEventListener('input', function() {
+            const searchQuery = this.value.toLowerCase();
+            tagSelect.innerHTML = ''; // Limpa as opções visíveis
+
+            // Filtra as opções que começam com o texto digitado
+            const filteredTags = allTags.filter(tag => tag.text.toLowerCase().startsWith(searchQuery));
+            
+            // Adiciona as opções filtradas de volta no select
+            filteredTags.forEach(tag => {
+                tagSelect.appendChild(tag);
+            });
+            updateSelectedTags();
+        });
         function updateSelectedTags() {
             const select = document.getElementById('tags');
             const selectedTagsContainer = document.getElementById('selected-tags');
             selectedTagsContainer.innerHTML = '';
 
-            Array.from(select.selectedOptions).forEach(option => {
+            Array.from(tagSelect.selectedOptions).forEach(option => {
                 const chip = document.createElement('span');
                 chip.classList.add('tag-chip');
                 chip.textContent = option.text;


### PR DESCRIPTION
Alterei a posição das informações das colunas da lista de API, que estavam desconfiguradas
![image](https://github.com/user-attachments/assets/ec4e25b4-7490-49b7-a3a0-940cc881cbda)

Antes de digitar no input, as tags cadastradas aparecem na lista 
![image](https://github.com/user-attachments/assets/5d0b70e2-9a66-4d56-9c42-e07d43e7fc9f)

Quando começamos a digitar, apenas as tags com aquele conjunto de caracteres que aparecem na lista
![image](https://github.com/user-attachments/assets/cda9b57a-5332-437e-8e53-ac676f011736)

Quando clicamos na tag, um badge é criado
![image](https://github.com/user-attachments/assets/7780396c-a929-4715-8e2b-808a45e3826d)

Ao digitar outra tag que comece com outra letra, o badge some e na lista só aparecem as tags com a letra digitada no input (tentei de tudo para manter o badge das tags que já  foram selecionadas quando muda a busca elástica, mas sempre da erro. Dessa forma foi a única que não da erro, salva no banco certinho e não quebra a tela)
![image](https://github.com/user-attachments/assets/bf8761da-c5e8-4e90-836d-470bf3e9c518)

Quando clicamos, sem precisar clicar no Ctrl ou Command, o badge da nova tag aparece
![image](https://github.com/user-attachments/assets/bf876a2c-38a9-4d69-bc38-b4421b5edc5d)

Mas quando limpamos o input, aparecem todas as tags que selecionamos até o momento.
![image](https://github.com/user-attachments/assets/0865ca78-cea8-4819-95d3-fe928eab34e9)

O Ctrl e command são usados quando o usuário quer selecionar mais de uma tag na mesma lista
