### PR TITLE
PYG-16/PYG-17/fix/consulta-por-data-colunas-lista-noticias

### DIFF
--- a/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
+++ b/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Comparator;
+import java.util.stream.Collectors;
 
 import edu.fatec.Porygon.service.NoticiaService;
 
@@ -62,8 +63,14 @@ public class NoticiaController {
         }
 
         List<Noticia> noticias = noticiaService.listarNoticiasPorData(dataInicio, dataFim);
-        noticias.sort(Comparator.comparing(Noticia::getData));
-        return ResponseEntity.ok(noticias);
+//        noticias.sort(Comparator.comparing(Noticia::getData));
+//        return ResponseEntity.ok(noticias);
+//    }
+        List<NoticiaDTO> noticiaDTOs = noticias.stream()
+                .map(NoticiaDTO::new)
+                .collect(Collectors.toList());
+        noticiaDTOs.sort(Comparator.comparing(NoticiaDTO::getData)); // Ordenação via DTO
+        return ResponseEntity.ok(noticiaDTOs); // Retornando DTOs, não entidades
     }
 
     @GetMapping("/associar-tags")

--- a/src/main/java/edu/fatec/Porygon/model/Noticia.java
+++ b/src/main/java/edu/fatec/Porygon/model/Noticia.java
@@ -1,5 +1,6 @@
 package edu.fatec.Porygon.model;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import java.util.Date;
 import java.util.List;
@@ -29,6 +30,7 @@ public class Noticia {
     private Portal portal;
 
     @ManyToMany
+    @JsonManagedReference
     @JoinTable(
         name = "noticia_tag",
         joinColumns = @JoinColumn(name = "noticia_id"),

--- a/src/main/java/edu/fatec/Porygon/model/Tag.java
+++ b/src/main/java/edu/fatec/Porygon/model/Tag.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -31,6 +32,10 @@ public class Tag {
 
     @ManyToMany(mappedBy = "tags")
     private Set<Portal> portais = new HashSet<>();
+
+    @ManyToMany(mappedBy = "tags")
+    @JsonBackReference
+    private Set<Noticia> noticias;
 
     public Integer getId() {
         return id;

--- a/src/main/java/edu/fatec/Porygon/service/DataScrapperService.java
+++ b/src/main/java/edu/fatec/Porygon/service/DataScrapperService.java
@@ -20,7 +20,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import edu.fatec.Porygon.service.NoticiaService;
 
 @Service
 public class DataScrapperService {

--- a/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
+++ b/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
@@ -4,8 +4,6 @@ import java.text.Normalizer;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 
 import edu.fatec.Porygon.model.Sinonimo;
@@ -13,10 +11,6 @@ import edu.fatec.Porygon.model.Tag;
 import edu.fatec.Porygon.repository.SinonimoRepository;
 import edu.fatec.Porygon.repository.TagRepository;
 
-import edu.fatec.Porygon.model.Sinonimo;
-import edu.fatec.Porygon.model.Tag;
-import edu.fatec.Porygon.repository.SinonimoRepository;
-import edu.fatec.Porygon.repository.TagRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import edu.fatec.Porygon.model.Noticia;

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -203,7 +203,6 @@
                 return;
             }
 
-
             fetch(`/noticias?dataInicio=${dataInicio.toISOString().split('T')[0]}&dataFim=${dataFim.toISOString().split('T')[0]}`)
                 .then(response => response.json())
                 .then(data => {
@@ -211,13 +210,16 @@
                     tbody.innerHTML = '';
                     data.forEach(noticia => {
                         const row = document.createElement('tr');
+                        const tags = noticia.tags.length > 0
+                            ? noticia.tags.map(tag => tag.nome).join(', ')
+                            : 'Sem tag associada';
+
                         row.innerHTML = `
-                            <td>Inativo</td>
-                            <td>${noticia.titulo}</td>
-                            <td>Inativo</td>
-                            <td>${new Date(noticia.data).toLocaleDateString('pt-BR', { timeZone: 'UTC' })}</td>
-                            <td><button class="btn btn-info" onclick="abrirModal(${noticia.id})">Abrir</button></td>
-                            `;
+                    <td>${noticia.titulo}</td>
+                    <td>${tags}</td>
+                    <td>${new Date(noticia.data).toLocaleDateString('pt-BR', { timeZone: 'UTC' })}</td>
+                    <td><button class="btn btn-info" onclick="abrirModal(${noticia.id})">Abrir</button></td>
+                `;
                         tbody.appendChild(row);
                     });
                 })


### PR DESCRIPTION
Corrige a consulta por data de notícias, listando por DTO e não por entidade
![image](https://github.com/user-attachments/assets/52769040-e5a4-4d2a-b8a0-1692d9a15578)

Corrige as colunas da lista de notícias quando nenhuma notícia tem tag
![image](https://github.com/user-attachments/assets/909d3b8d-2b2b-4aff-b704-de85ef1d409d)