### PR TITLE
PYG-122 PYG-123 perf(NoticiaService): modifica o método que associa as tags e salva a noticia

### DIFF
--- a/codebase/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/controller/NoticiaController.java
@@ -67,21 +67,8 @@ public class NoticiaController {
         List<NoticiaDTO> noticiaDTOs = noticias.stream()
                 .map(NoticiaDTO::new)
                 .collect(Collectors.toList());
-            noticiaDTOs.sort(Comparator.comparing(NoticiaDTO::getData));
-            return ResponseEntity.ok(noticiaDTOs);
-}
-
-    @GetMapping("/associar-tags")
-    @ResponseBody
-    public ResponseEntity<String> associarTagsANoticias() {
-        try {
-            noticiaService.findTagsInTitle();
-            noticiaService.associarTagsPorConteudo();
-            return ResponseEntity.ok("Tags associadas com sucesso às notícias.");
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("Erro ao associar tags às notícias: " + e.getMessage());
-        }
+        noticiaDTOs.sort(Comparator.comparing(NoticiaDTO::getData));
+        return ResponseEntity.ok(noticiaDTOs);
     }
 
 }

--- a/codebase/src/main/java/edu/fatec/Porygon/model/ApiDados.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/model/ApiDados.java
@@ -12,7 +12,7 @@ public class ApiDados {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "NVARCHAR(MAX)")
     private String conteudo;
 
     private String descricao;

--- a/codebase/src/main/java/edu/fatec/Porygon/repository/TagRepository.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/repository/TagRepository.java
@@ -4,10 +4,13 @@ import edu.fatec.Porygon.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Integer> {
     boolean existsByNome(String nome);
     Optional<Tag> findByNome(String nome);
+
+    List<Tag> findAllByPortais_Id(Integer portalId);
 }

--- a/codebase/src/main/java/edu/fatec/Porygon/service/DataScrapperService.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/service/DataScrapperService.java
@@ -2,7 +2,6 @@ package edu.fatec.Porygon.service;
 
 import edu.fatec.Porygon.model.Noticia;
 import edu.fatec.Porygon.model.Portal;
-import edu.fatec.Porygon.model.Tag;
 import edu.fatec.Porygon.model.Jornalista;
 import edu.fatec.Porygon.repository.NoticiaRepository;
 import edu.fatec.Porygon.repository.PortalRepository;
@@ -23,7 +22,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 public class DataScrapperService {
@@ -52,7 +50,6 @@ public class DataScrapperService {
         String url = portal.getUrl();
 
         try {
-            List<Noticia> noticias = new ArrayList<>();
             Element Titulo, Data, Autor;
             Elements Conteudo;
 
@@ -62,10 +59,6 @@ public class DataScrapperService {
             for (Element selector : selectPag) {
                 Links.add(selector.absUrl("href"));
             }
-
-            List<String> tagsAssociadas = portal.getTags().stream()
-                    .map(Tag::getNome) // Bsp
-                    .collect(Collectors.toList());
 
             for (String link : Links) {
                 Document linkDoc = Jsoup.connect(link).get();
@@ -108,12 +101,8 @@ public class DataScrapperService {
                 noticia.setConteudo(contentScrapper);
                 noticia.setHref(link);
 
-                List<Integer> tagIds = portal.getTags().stream()
-                        .map(Tag::getId)
-                        .collect(Collectors.toList());
-
                 if (!noticiaRepository.existsByHref(noticia.getHref())) {
-                    noticiaService.salvar(noticia, tagIds);
+                    noticiaService.salvar(noticia);
                 } else {
                     System.out.println("Notícia já existente: " + noticia.getHref());
                 }
@@ -152,9 +141,6 @@ public class DataScrapperService {
             }
         }
 
-        noticiaService.findTagsInTitle();
-        noticiaService.associarTagsPorConteudo();
-
         hideLoading();
     }
 
@@ -192,9 +178,6 @@ public class DataScrapperService {
                     }
                 }
             }
-
-            noticiaService.findTagsInTitle();
-            noticiaService.associarTagsPorConteudo();
         }
     }
 
@@ -254,8 +237,6 @@ public class DataScrapperService {
                     }
                 }
             }
-            noticiaService.findTagsInTitle();
-            noticiaService.associarTagsPorConteudo();
         }
     }
 

--- a/codebase/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
@@ -34,14 +34,19 @@ public class NoticiaService {
     }
 
     public Noticia salvar(Noticia noticia) {
-        Noticia savedNoticia = noticiaRepository.save(noticia);
-        associarTags(savedNoticia);
+        Set<Tag> foundTags = associarTags(noticia);
 
-        return savedNoticia;
+        if (foundTags.isEmpty()) {
+            System.out.println("Notícia não possui tags, não será salva.");
+            return null;
+        }
+
+        noticia.setTags(foundTags);
+        return noticiaRepository.save(noticia);
     }
 
-    private void associarTags(Noticia noticia) {
-        Set<Tag> tagsPortal = new HashSet<>(tagRepository.findAllByPortais_Id(noticia.getPortal().getId())); 
+    private Set<Tag> associarTags(Noticia noticia) {
+        Set<Tag> tagsPortal = new HashSet<>(tagRepository.findAllByPortais_Id(noticia.getPortal().getId()));
 
         Set<Tag> foundTags = encontrarTagsNoTitulo(noticia.getTitulo(), tagsPortal);
         if (foundTags.isEmpty()) {
@@ -51,8 +56,7 @@ public class NoticiaService {
             foundTags = encontrarSinonimos(noticia.getTitulo(), noticia.getConteudo(), tagsPortal);
         }
 
-        noticia.setTags(foundTags);
-        noticiaRepository.save(noticia);
+        return foundTags;
     }
 
     private Set<Tag> encontrarTagsNoTitulo(String titulo, Set<Tag> tagsPortal) {

--- a/codebase/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/service/NoticiaService.java
@@ -8,7 +8,6 @@ import edu.fatec.Porygon.model.Sinonimo;
 import edu.fatec.Porygon.model.Tag;
 import edu.fatec.Porygon.repository.SinonimoRepository;
 import edu.fatec.Porygon.repository.TagRepository;
-import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import edu.fatec.Porygon.model.Noticia;
@@ -34,155 +33,79 @@ public class NoticiaService {
         return noticiaRepository.searchNewsByData(dataInicio, dataFim);
     }
 
-    public Noticia salvar(Noticia noticia, List<Integer> tagIds) {
-        if (tagIds != null && !tagIds.isEmpty()) {
-            Set<Tag> tagsPortal = new HashSet<>(tagRepository.findAllById(tagIds));
-            associarTagsRelevantes(noticia, tagsPortal);
-        }
-        return noticiaRepository.save(noticia);
+    public Noticia salvar(Noticia noticia) {
+        Noticia savedNoticia = noticiaRepository.save(noticia);
+        associarTags(savedNoticia);
+
+        return savedNoticia;
     }
 
-    public Noticia atualizarTags(Integer noticiaId, List<Integer> tagIds) {
-        Noticia noticia = noticiaRepository.findById(noticiaId)
-                .orElseThrow(() -> new RuntimeException("Notícia não encontrada"));
+    private void associarTags(Noticia noticia) {
+        Set<Tag> tagsPortal = new HashSet<>(tagRepository.findAllByPortais_Id(noticia.getPortal().getId())); 
 
-        if (tagIds != null) {
-            Set<Tag> tagsPortal = tagIds.isEmpty()
-                    ? new HashSet<>()
-                    : new HashSet<>(tagRepository.findAllById(tagIds));
-            associarTagsRelevantes(noticia, tagsPortal);
+        Set<Tag> foundTags = encontrarTagsNoTitulo(noticia.getTitulo(), tagsPortal);
+        if (foundTags.isEmpty()) {
+            foundTags = encontrarTagsNoConteudo(noticia.getConteudo(), tagsPortal);
+        }
+        if (foundTags.isEmpty()) {
+            foundTags = encontrarSinonimos(noticia.getTitulo(), noticia.getConteudo(), tagsPortal);
         }
 
-        return noticiaRepository.save(noticia);
+        noticia.setTags(foundTags);
+        noticiaRepository.save(noticia);
     }
 
-    @Transactional
-    public void findTagsInTitle() {
-        List<Tag> tags = tagRepository.findAll();
-        List<Noticia> news = noticiaRepository.findAll();
+    private Set<Tag> encontrarTagsNoTitulo(String titulo, Set<Tag> tagsPortal) {
+        Set<Tag> foundTags = new HashSet<>();
+        String tituloNormalizado = normalizarTexto(titulo); 
+        for (Tag tag : tagsPortal) {
+            String tagNormalizada = normalizarTexto(tag.getNome()); 
+            if (tituloNormalizado.contains(tagNormalizada)) {
+                foundTags.add(tag);
+            }
+        }
+        return foundTags;
+    }
 
-        for (Noticia noticia : news) {
-            HashSet<Tag> foundTags = new HashSet<>();
-            for (Tag tag : tags) {
-                if (noticia.getTitulo().toLowerCase().contains(tag.getNome().toLowerCase())) {
+    private Set<Tag> encontrarTagsNoConteudo(String conteudo, Set<Tag> tagsPortal) {
+        Set<Tag> foundTags = new HashSet<>();
+        String conteudoNormalizado = normalizarTexto(conteudo);
+        for (Tag tag : tagsPortal) {
+            String tagNormalizada = normalizarTexto(tag.getNome()); 
+            if (conteudoNormalizado.contains(tagNormalizada)) {
+                foundTags.add(tag);
+            }
+        }
+        return foundTags;
+    }
+
+    private Set<Tag> encontrarSinonimos(String titulo, String conteudo, Set<Tag> tagsPortal) {
+        Set<Tag> foundTags = new HashSet<>();
+        String tituloNormalizado = normalizarTexto(titulo);
+        String conteudoNormalizado = normalizarTexto(conteudo); 
+        for (Tag tag : tagsPortal) {
+            List<Sinonimo> sinonimos = sinonimoRepository.findByTag(tag);
+            for (Sinonimo sinonimo : sinonimos) {
+                String sinonimoNormalizado = normalizarTexto(sinonimo.getNome()); 
+                if (tituloNormalizado.contains(sinonimoNormalizado) ||
+                        conteudoNormalizado.contains(sinonimoNormalizado)) {
                     foundTags.add(tag);
-                } else {
-                    Tag tagFound = searchSynonymsInTitle(tag, noticia);
-                    if (tagFound != null) {
-                        foundTags.add(tagFound);
-                    }
-                }
-            }
-
-            if (!foundTags.isEmpty()) {
-                noticia.setTags(foundTags);
-                noticiaRepository.save(noticia);
-            }
-
-            associarTagsPorConteudo();
-        }
-    }
-
-
-    public Tag searchSynonymsInTitle(Tag tag, Noticia noticia) {
-        List<Sinonimo> sinonimos = sinonimoRepository.findByTag(tag);
-        Tag retorno = null;
-
-        String cleanTitleAccent = Normalizer.normalize(noticia.getTitulo(), Normalizer.Form.NFD).replaceAll("\\p{InCombiningDiacriticalMarks}", "");
-        String cleanTitleSpecialCharacter = cleanTitleAccent.replaceAll("[^a-zA-Z0-9\\s]", "").toLowerCase();
-        String[] words = cleanTitleSpecialCharacter.split("\\s+");
-
-        for (String word : words) {
-            for(Sinonimo sinonimo : sinonimos) {
-                if (sinonimo.getNome().toLowerCase().equals(word)){
-                    return tag;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    @Transactional
-    public void associarTagsPorConteudo() {
-        List<Tag> tags = tagRepository.findAll();
-        List<Noticia> noticias = noticiaRepository.findAll();
-
-        for (Noticia noticia : noticias) {
-            for (Tag tag : tags) {
-                if (buscarSinonimoNoConteudo(tag, noticia)) {
-                    if (noticia.getTags() == null) {
-                        noticia.setTags(new HashSet<>()); 
-                    }
-
-                    if (!noticia.getTags().contains(tag)) {
-                        noticia.getTags().add(tag);
-                        noticiaRepository.save(noticia);
-                    }
-
                     break;
                 }
             }
         }
-    }
-
-    private boolean buscarSinonimoNoConteudo(Tag tag, Noticia noticia) {
-        List<Sinonimo> sinonimos = sinonimoRepository.findByTag(tag);
-
-        String conteudoLimpo = Normalizer.normalize(noticia.getConteudo(), Normalizer.Form.NFD)
-                .replaceAll("\\p{InCombiningDiacriticalMarks}", "")
-                .replaceAll("[^a-zA-Z0-9\\s]", "").toLowerCase();
-
-        String[] palavrasConteudo = conteudoLimpo.split("\\s+");
-
-        for (String palavra : palavrasConteudo) {
-            for (Sinonimo sinonimo : sinonimos) {
-                if (sinonimo.getNome().toLowerCase().equals(palavra)) {
-                    return true; 
-                }
-            }
-        }
-        return false; 
-    }
-
-    private void associarTagsRelevantes(Noticia noticia, Set<Tag> tagsPortal) {
-        Set<Tag> tagsRelevantes = new HashSet<>();
-
-        String conteudoNormalizado = normalizarTexto(noticia.getConteudo());
-        String tituloNormalizado = normalizarTexto(noticia.getTitulo());
-
-        for (Tag tag : tagsPortal) {
-            String tagNormalizada = normalizarTexto(tag.getNome());
-            String[] palavrasTag = tagNormalizada.split("[-\\s]");
-            boolean tagEncontrada;
-
-            if (palavrasTag.length > 1) {
-                tagEncontrada = Arrays.stream(palavrasTag)
-                        .allMatch(palavra -> conteudoNormalizado.contains(palavra) ||
-                                tituloNormalizado.contains(palavra));
-            } else {
-                tagEncontrada = conteudoNormalizado.contains(tagNormalizada) ||
-                        tituloNormalizado.contains(tagNormalizada);
-            }
-
-            if (tagEncontrada) {
-                tagsRelevantes.add(tag);
-            }
-        }
-
-        noticia.setTags(tagsRelevantes);
+        return foundTags;
     }
 
     private String normalizarTexto(String texto) {
-        if (texto == null)
-            return "";
-        return texto.toLowerCase()
-                .replaceAll("[áàãâä]", "a")
-                .replaceAll("[éèêë]", "e")
-                .replaceAll("[íìîï]", "i")
-                .replaceAll("[óòõôö]", "o")
-                .replaceAll("[úùûü]", "u")
-                .replaceAll("[ç]", "c")
-                .replaceAll("[^a-z0-9\\s-]", "");
+        if (texto == null) {
+            return null;
+        }
+
+        texto = texto.toLowerCase();
+        texto = Normalizer.normalize(texto, Normalizer.Form.NFD);
+        texto = texto.replaceAll("[^\\p{ASCII}]", "");
+
+        return texto;
     }
 }


### PR DESCRIPTION
Cadastrei um portal do G1 de Agronegocios e associei a tag LULA.
Resultado do console:
![image](https://github.com/user-attachments/assets/9e7e5986-4062-42a1-a422-794e5ab46f91)

No NoticiaService:

´´´
    public Noticia salvar(Noticia noticia) {
        Set<Tag> foundTags = associarTags(noticia);

        // Se não houver tags associadas, não salva a notícia
        if (foundTags.isEmpty()) {
            System.out.println("Notícia não possui tags, não será salva.");
            return null;
        }

        // Associa as tags e salva a notícia
        noticia.setTags(foundTags);
        return noticiaRepository.save(noticia);
    }

    private Set<Tag> associarTags(Noticia noticia) {
        Set<Tag> tagsPortal = new HashSet<>(tagRepository.findAllByPortais_Id(noticia.getPortal().getId()));

        Set<Tag> foundTags = encontrarTagsNoTitulo(noticia.getTitulo(), tagsPortal);
        if (foundTags.isEmpty()) {
            foundTags = encontrarTagsNoConteudo(noticia.getConteudo(), tagsPortal);
        }
        if (foundTags.isEmpty()) {
            foundTags = encontrarSinonimos(noticia.getTitulo(), noticia.getConteudo(), tagsPortal);
        }

        return foundTags;
    }
    ```
    
    Alterei o método do **salvar**, primeiro ele associa as tags e depois verifica se há tag na noticia se sim ele salva , caso contrario ele ignora.
    
   Mudei o retorno do **associartags** para a variável que estou chamando no inicio do método **salvar**.