### PR TITLE
Fix: edição do portal deve manter ultimaatualizacao e hastoday 

### DIFF
--- a/codebase/src/main/java/edu/fatec/Porygon/controller/PortalController.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/controller/PortalController.java
@@ -129,9 +129,13 @@ public class PortalController {
             return "portal";
         }
     
-        successMessage = "Portal salvo com sucesso!";
-        model.addAttribute("successMessage", successMessage);
-        return "redirect:/portais";
+        if (isEdit) {
+            successMessage = "Portal editado com sucesso!";
+        } else {
+            successMessage = "Portal salvo com sucesso!";
+        }
+
+        return "redirect:/portais?successMessage=" + successMessage
     }
 
     @PostMapping("/alterarStatus/{id}")

--- a/codebase/src/main/java/edu/fatec/Porygon/controller/PortalController.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/controller/PortalController.java
@@ -68,16 +68,16 @@ public class PortalController {
             @RequestParam("isEdit") boolean isEdit,
             @RequestParam(required = false) String tagIds,
             Model model) {
-
+    
         String errorMessage = null;
         String successMessage = null;
-
+    
         List<Integer> tagIdsList = processarTags(tagIds);
         if (tagIdsList != null) {
             Set<Tag> tags = new HashSet<>(tagRepository.findAllById(tagIdsList));
             portal.setTags(tags);
         }
-
+    
         try {
             dataScrapperService.validarSeletores(portal);
         } catch (IllegalArgumentException e) {
@@ -85,28 +85,37 @@ public class PortalController {
         } catch (RuntimeException e) {
             errorMessage = "Erro ao acessar a URL: " + e.getMessage();
         }
-
+    
         if (errorMessage != null) {
             carregarModelBase(model, portal);
             model.addAttribute("errorMessage", errorMessage);
             return "portal";
         }
-
+    
         if (isEdit) {
             errorMessage = verificarDuplicidadeParaEdicao(portal);
         } else {
             errorMessage = verificarDuplicidadeParaCadastro(portal);
         }
-
+    
         if (errorMessage != null) {
             carregarModelBase(model, portal);
             model.addAttribute("errorMessage", errorMessage);
             return "portal";
         }
-
+    
         ajustarDatasCadastroEdicao(portal, isEdit);
+    
+        if (isEdit) {
+            Portal portalExistente = portalRepository.findById(portal.getId())
+                .orElseThrow(() -> new RuntimeException("Portal não encontrado"));
+            
+            portal.setUltimaAtualizacao(portalExistente.getUltimaAtualizacao());
+            portal.setHasScrapedToday(portalExistente.isHasScrapedToday());
+        }
+    
         portalRepository.save(portal);
-
+    
         try {
             if (!isEdit && portal.isAtivo() && !portal.isHasScrapedToday()) {
                 dataScrapperService.WebScrapper();
@@ -119,7 +128,7 @@ public class PortalController {
             model.addAttribute("errorMessage", errorMessage);
             return "portal";
         }
-
+    
         successMessage = "Portal salvo com sucesso!";
         model.addAttribute("successMessage", successMessage);
         return "redirect:/portais";

--- a/codebase/src/main/java/edu/fatec/Porygon/controller/PortalController.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/controller/PortalController.java
@@ -135,7 +135,7 @@ public class PortalController {
             successMessage = "Portal salvo com sucesso!";
         }
 
-        return "redirect:/portais?successMessage=" + successMessage
+        return "redirect:/portais?successMessage=" + successMessage;
     }
 
     @PostMapping("/alterarStatus/{id}")

--- a/codebase/src/main/java/edu/fatec/Porygon/service/PortalService.java
+++ b/codebase/src/main/java/edu/fatec/Porygon/service/PortalService.java
@@ -61,16 +61,19 @@ public class PortalService {
     public Portal atualizar(Portal portal, List<Integer> tagIds) {
         Portal portalExistente = portalRepository.findById(portal.getId())
             .orElseThrow(() -> new RuntimeException("Portal não encontrado"));
-
+    
         portal.setDataCriacao(portalExistente.getDataCriacao());
         
+        portal.setUltimaAtualizacao(portalExistente.getUltimaAtualizacao());
+        portal.setHasScrapedToday(portalExistente.isHasScrapedToday());
+    
         if (tagIds != null) {
             Set<Tag> novasTags = tagIds.isEmpty() 
                 ? new HashSet<>() 
                 : new HashSet<>(tagRepository.findAllById(tagIds));
             portal.setTags(novasTags);
         }
-
+    
         return portalRepository.save(portal);
     }
 


### PR DESCRIPTION
Quando se editava um portal , ele perdia a data da ultima atualização e desativava o scrapping do dia.
Identificado na Sprint/4

![image](https://github.com/user-attachments/assets/ab98846a-2933-41ea-9bb3-dfa01f13c4e2)
apos editar 
![image](https://github.com/user-attachments/assets/87159098-6e65-4e35-9dd5-2208d09b64a9)

 agora com as modificações 
 
![image](https://github.com/user-attachments/assets/1166608f-417a-4a88-9a72-0d5afe9af085)

